### PR TITLE
Implement _mm_sub_epi64 and _mm_mul_epu32

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1706,12 +1706,17 @@ FORCE_INLINE __m128 _mm_mul_ps(__m128 a, __m128 b)
 // Multiply the low unsigned 32-bit integers from each packed 64-bit element in
 // a and b, and store the unsigned 64-bit results in dst.
 //
-//   r0 :=  (int32_t*)a0 * (int32_t*)b0
-//   r1 :=  (int32_t*)a3 * (int32_t*)b3
+//   r0 :=  (uint32_t*)a0 * (uint32_t*)b0
+//   r1 :=  (uint32_t*)a3 * (uint32_t*)b3
 FORCE_INLINE __m128i _mm_mul_epu32(__m128i a, __m128i b)
 {
+    // Mask out the high 32-bit integers and then multiply them as 64-bit
+    uint32_t __attribute__((aligned(16)))
+    data[4] = {0xFFFFFFFF, 0, 0xFFFFFFFF, 0};
+    __m128i mask = vreinterpretq_m128i_u32(vld1q_u32(data));
     return vreinterpretq_m128i_u32(
-        vmulq_u32(vreinterpretq_u32_m128i(a), vreinterpretq_u32_m128i(b)));
+        vmulq_u32(vreinterpretq_u32_m128i(_mm_and_si128(a, mask)),
+                  vreinterpretq_u32_m128i(_mm_and_si128(b, mask))));
 }
 
 // Multiplies the 8 signed 16-bit integers from a by the 8 signed 16-bit

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1739,7 +1739,7 @@ FORCE_INLINE __m128i _mm_mul_epu32(__m128i a, __m128i b)
         *(__m128i *) (&vzip_u32(vget_low_u32(vreinterpretq_u32_m128i(b)),
                                 vget_high_u32(vreinterpretq_u32_m128i(b))));
 
-    // Multiply low word (32 bit) against low word (24 bit) and high word (32
+    // Multiply low word (32 bit) against low word (34 bit) and high word (32
     // bit) against high word (32 bit). Pack both results (64 bit) into 128 bit
     // register and return result.
     return vreinterpretq_m128i_u64(

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1473,6 +1473,16 @@ FORCE_INLINE __m128 _mm_sub_ps(__m128 a, __m128 b)
         vsubq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
 }
 
+// Subtract 2 packed 64-bit integers in b from 2 packed 64-bit integers in a,
+// and store the results in dst.
+//    r0 := a0 - b0
+//    r1 := a1 - b1
+FORCE_INLINE __m128i _mm_sub_epi64(__m128i a, __m128i b)
+{
+    return vreinterpretq_m128i_s64(
+        vsubq_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(b)));
+}
+
 // Subtracts the 4 signed or unsigned 32-bit integers of b from the 4 signed or
 // unsigned 32-bit integers of a.
 //
@@ -1691,6 +1701,17 @@ FORCE_INLINE __m128 _mm_mul_ps(__m128 a, __m128 b)
 {
     return vreinterpretq_m128_f32(
         vmulq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+}
+
+// Multiply the low unsigned 32-bit integers from each packed 64-bit element in
+// a and b, and store the unsigned 64-bit results in dst.
+//
+//   r0 :=  (int32_t*)a0 * (int32_t*)b0
+//   r1 :=  (int32_t*)a3 * (int32_t*)b3
+FORCE_INLINE __m128i _mm_mul_epu32(__m128i a, __m128i b)
+{
+    return vreinterpretq_m128i_u32(
+        vmulq_u32(vreinterpretq_u32_m128i(a), vreinterpretq_u32_m128i(b)));
 }
 
 // Multiplies the 8 signed 16-bit integers from a by the 8 signed 16-bit

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -210,7 +210,7 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
         ret = "MM_MULLO_EPI32";
         break;
     case IT_MM_MUL_EPU32:
-        ret = "IT_MM_MUL_EPU32";
+        ret = "MM_MUL_EPU32";
         break;
     case IT_MM_MUL_PS:
         ret = "MM_MUL_PS";
@@ -480,6 +480,14 @@ bool validate128(__m128i a, __m128i b)
     ASSERT_RETURN(t1[2] == t2[2]);
     ASSERT_RETURN(t1[1] == t2[1]);
     ASSERT_RETURN(t1[0] == t2[0]);
+    return true;
+}
+
+bool validateUInt64(__m128i a, uint64_t x, uint64_t y)
+{
+    const uint64_t *t = (const uint64_t *) &a;
+    ASSERT_RETURN(t[1] == x);
+    ASSERT_RETURN(t[0] == y);
     return true;
 }
 
@@ -1006,8 +1014,8 @@ bool test_mm_sub_epi64(const int64_t *_a, const int64_t *_b)
     int64_t d0 = _a[0] - _b[0];
     int64_t d1 = _a[1] - _b[1];
 
-    __m128i a = test_mm_load_ps((int32_t *) _a);
-    __m128i b = test_mm_load_ps((int32_t *) _b);
+    __m128i a = test_mm_load_ps((const int32_t *) _a);
+    __m128i b = test_mm_load_ps((const int32_t *) _b);
     __m128i c = _mm_sub_epi64(a, b);
     return validateInt64(c, d1, d0);
 }
@@ -1057,14 +1065,13 @@ bool test_mm_mullo_epi16(const int16_t *_a, const int16_t *_b)
 
 bool test_mm_mul_epu32(const uint32_t *_a, const uint32_t *_b)
 {
-    int64_t dx = _a[0] - _b[0];
-    int64_t dy = _a[2] - _b[2];
+    uint64_t dx = _a[0] * _b[0];
+    uint64_t dy = _a[2] * _b[2];
 
-    __m128i a = test_mm_load_ps((int32_t *) _a);
-    __m128i b = test_mm_load_ps((int32_t *) _b);
+    __m128i a = test_mm_load_ps((const int32_t *) _a);
+    __m128i b = test_mm_load_ps((const int32_t *) _b);
     __m128i c = _mm_mul_epu32(a, b);
-    return validateInt(c, ((int32_t *) &dy)[0], ((int32_t *) &dy)[1],
-                       ((int32_t *) &dx)[0], ((int32_t *) &dx)[1]);
+    return validateUInt64(c, dy, dx);
 }
 
 bool test_mm_madd_epi16(const int16_t *_a, const int16_t *_b)
@@ -2451,6 +2458,7 @@ public:
         case IT_MM_MUL_EPU32:
             ret = test_mm_mul_epu32((const uint32_t *) mTestIntPointer1,
                                     (const uint32_t *) mTestIntPointer2);
+            break;
         case IT_MM_ADD_EPI16:
             ret = true;
             break;

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -1071,22 +1071,7 @@ bool test_mm_mul_epu32(const uint32_t *_a, const uint32_t *_b)
     __m128i a = _mm_loadu_si128((const __m128i *) _a);
     __m128i b = _mm_loadu_si128((const __m128i *) _b);
     __m128i r = _mm_mul_epu32(a, b);
-    ASSERT_RETURN(validateUInt64(r, dy, dx));
-
-    __m128i t1;
-    vreinterpretq_nth_u64_m128i(t1, 0) =
-        (uint64_t)(vreinterpretq_nth_u32_m128i(a, 0)) *
-        (uint64_t)(vreinterpretq_nth_u32_m128i(b, 0));
-    vreinterpretq_nth_u64_m128i(t1, 1) =
-        (uint64_t)(vreinterpretq_nth_u32_m128i(a, 2)) *
-        (uint64_t)(vreinterpretq_nth_u32_m128i(b, 2));
-
-    __m128i t2;
-    vreinterpretq_nth_u64_m128i(t2, 0) = (uint64_t)(_a[0]) * (uint64_t)(_b[0]);
-    vreinterpretq_nth_u64_m128i(t2, 1) = (uint64_t)(_a[2]) * (uint64_t)(_b[2]);
-
-    ASSERT_RETURN(validate128(r, t1));
-    return validate128(r, t2);
+    return validateUInt64(r, dy, dx);
 }
 
 bool test_mm_madd_epi16(const int16_t *_a, const int16_t *_b)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -1065,13 +1065,28 @@ bool test_mm_mullo_epi16(const int16_t *_a, const int16_t *_b)
 
 bool test_mm_mul_epu32(const uint32_t *_a, const uint32_t *_b)
 {
-    uint64_t dx = _a[0] * _b[0];
-    uint64_t dy = _a[2] * _b[2];
+    uint64_t dx = (uint64_t)(_a[0]) * (uint64_t)(_b[0]);
+    uint64_t dy = (uint64_t)(_a[2]) * (uint64_t)(_b[2]);
 
-    __m128i a = test_mm_load_ps((const int32_t *) _a);
-    __m128i b = test_mm_load_ps((const int32_t *) _b);
-    __m128i c = _mm_mul_epu32(a, b);
-    return validateUInt64(c, dy, dx);
+    __m128i a = _mm_loadu_si128((const __m128i *) _a);
+    __m128i b = _mm_loadu_si128((const __m128i *) _b);
+    __m128i r = _mm_mul_epu32(a, b);
+    ASSERT_RETURN(validateUInt64(r, dy, dx));
+
+    __m128i t1;
+    vreinterpretq_nth_u64_m128i(t1, 0) =
+        (uint64_t)(vreinterpretq_nth_u32_m128i(a, 0)) *
+        (uint64_t)(vreinterpretq_nth_u32_m128i(b, 0));
+    vreinterpretq_nth_u64_m128i(t1, 1) =
+        (uint64_t)(vreinterpretq_nth_u32_m128i(a, 2)) *
+        (uint64_t)(vreinterpretq_nth_u32_m128i(b, 2));
+
+    __m128i t2;
+    vreinterpretq_nth_u64_m128i(t2, 0) = (uint64_t)(_a[0]) * (uint64_t)(_b[0]);
+    vreinterpretq_nth_u64_m128i(t2, 1) = (uint64_t)(_a[2]) * (uint64_t)(_b[2]);
+
+    ASSERT_RETURN(validate128(r, t1));
+    return validate128(r, t2);
 }
 
 bool test_mm_madd_epi16(const int16_t *_a, const int16_t *_b)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -182,6 +182,9 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
     case IT_MM_SUB_PS:
         ret = "MM_SUB_PS";
         break;
+    case IT_MM_SUB_EPI64:
+        ret = "MM_SUB_EPI64";
+        break;
     case IT_MM_SUB_EPI32:
         ret = "MM_SUB_EPI32";
         break;
@@ -205,6 +208,9 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
         break;
     case IT_MM_MULLO_EPI32:
         ret = "MM_MULLO_EPI32";
+        break;
+    case IT_MM_MUL_EPU32:
+        ret = "IT_MM_MUL_EPU32";
         break;
     case IT_MM_MUL_PS:
         ret = "MM_MUL_PS";
@@ -474,6 +480,14 @@ bool validate128(__m128i a, __m128i b)
     ASSERT_RETURN(t1[2] == t2[2]);
     ASSERT_RETURN(t1[1] == t2[1]);
     ASSERT_RETURN(t1[0] == t2[0]);
+    return true;
+}
+
+bool validateInt64(__m128i a, int64_t x, int64_t y)
+{
+    const int64_t *t = (const int64_t *) &a;
+    ASSERT_RETURN(t[1] == x);
+    ASSERT_RETURN(t[0] == y);
     return true;
 }
 
@@ -987,6 +1001,17 @@ bool test_mm_sub_epi32(const int32_t *_a, const int32_t *_b)
     return validateInt(c, dw, dz, dy, dx);
 }
 
+bool test_mm_sub_epi64(const int64_t *_a, const int64_t *_b)
+{
+    int64_t d0 = _a[0] - _b[0];
+    int64_t d1 = _a[1] - _b[1];
+
+    __m128i a = test_mm_load_ps((int32_t *) _a);
+    __m128i b = test_mm_load_ps((int32_t *) _b);
+    __m128i c = _mm_sub_epi64(a, b);
+    return validateInt64(c, d1, d0);
+}
+
 bool test_mm_add_ps(const float *_a, const float *_b)
 {
     float dx = _a[0] + _b[0];
@@ -1028,6 +1053,18 @@ bool test_mm_mullo_epi16(const int16_t *_a, const int16_t *_b)
     __m128i b = test_mm_load_ps((const int32_t *) _b);
     __m128i c = _mm_mullo_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
+}
+
+bool test_mm_mul_epu32(const uint32_t *_a, const uint32_t *_b)
+{
+    int64_t dx = _a[0] - _b[0];
+    int64_t dy = _a[2] - _b[2];
+
+    __m128i a = test_mm_load_ps((int32_t *) _a);
+    __m128i b = test_mm_load_ps((int32_t *) _b);
+    __m128i c = _mm_mul_epu32(a, b);
+    return validateInt(c, ((int32_t *) &dy)[0], ((int32_t *) &dy)[1],
+                       ((int32_t *) &dx)[0], ((int32_t *) &dx)[1]);
 }
 
 bool test_mm_madd_epi16(const int16_t *_a, const int16_t *_b)
@@ -2273,6 +2310,10 @@ public:
         case IT_MM_SUB_PS:
             ret = test_mm_sub_ps(mTestFloatPointer1, mTestFloatPointer2);
             break;
+        case IT_MM_SUB_EPI64:
+            ret = test_mm_sub_epi64((int64_t *) mTestIntPointer1,
+                                    (int64_t *) mTestIntPointer2);
+            break;
         case IT_MM_SUB_EPI32:
             ret = test_mm_sub_epi32(mTestIntPointer1, mTestIntPointer2);
             break;
@@ -2407,6 +2448,9 @@ public:
         case IT_MM_MULLO_EPI32:
             ret = true;
             break;
+        case IT_MM_MUL_EPU32:
+            ret = test_mm_mul_epu32((const uint32_t *) mTestIntPointer1,
+                                    (const uint32_t *) mTestIntPointer2);
         case IT_MM_ADD_EPI16:
             ret = true;
             break;

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -37,6 +37,7 @@ enum InstructionTest {
     IT_MM_MOVEMASK_PS,    // Unit test implemented and verified as fully working
     IT_MM_MOVEMASK_EPI8,  // Unit test implemented and verified as fully working
     IT_MM_SUB_PS,         // Unit test implemented and verified as fully working
+    IT_MM_SUB_EPI64,      // Unit test implemented
     IT_MM_SUB_EPI32,      // Unit test implemented and verified as fully working
     IT_MM_ADD_PS,         // Unit test implemented and verified as fully working
     IT_MM_ADD_EPI32,      // Unit test implemented and verified as fully working
@@ -79,6 +80,7 @@ enum InstructionTest {
     IT_MM_ADD_EPI16,                 // Unit test *not yet implemented*
     IT_MM_MADD_EPI16,     // Unit test implemented and verified as fully working
     IT_MM_MULLO_EPI32,    // Unit test *not yet implemented*
+    IT_MM_MUL_EPU32,      // Unit test implemented
     IT_MM_DIV_PS,         // Unit test *not yet implemented*
     IT_MM_DIV_SS,         // Unit test *not yet implemented*
     IT_MM_SQRT_PS,        // Unit test *not yet implemented*


### PR DESCRIPTION
Includes unit tests.
Verified working in a relatively complex code base that uses them.
_mm_mul_epu32 is currently implemented as c code and not neon instructions as I've failed to find the right neon instructions to have it work. I've left the skeleton of the neon implementation in place in case an appropriate instruction becomes available or someone else wants to try make it work.
I'm also happy to try write it using different instructions if anyone can suggest ones that might work.
