### PR TITLE
fix: Fix single-precision floating-point comparison instructions

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2195,10 +2195,10 @@ FORCE_INLINE int _mm_comilt_ss(__m128 a, __m128 b)
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a));
     uint32x4_t b_not_nan =
         vceqq_f32(vreinterpretq_f32_m128(b), vreinterpretq_f32_m128(b));
-    uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+    uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_lt_b =
         vcltq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_lt_b), 0) != 0) ? 1 : 0;
+    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_lt_b), 0) != 0) ? 1 : 0;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -2229,10 +2229,10 @@ FORCE_INLINE int _mm_comile_ss(__m128 a, __m128 b)
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a));
     uint32x4_t b_not_nan =
         vceqq_f32(vreinterpretq_f32_m128(b), vreinterpretq_f32_m128(b));
-    uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+    uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_le_b =
         vcleq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_le_b), 0) != 0) ? 1 : 0;
+    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_le_b), 0) != 0) ? 1 : 0;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -2263,10 +2263,10 @@ FORCE_INLINE int _mm_comieq_ss(__m128 a, __m128 b)
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a));
     uint32x4_t b_not_nan =
         vceqq_f32(vreinterpretq_f32_m128(b), vreinterpretq_f32_m128(b));
-    uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+    uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_eq_b =
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_eq_b), 0) != 0) ? 1 : 0;
+    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_eq_b), 0) != 0) ? 1 : 0;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -2280,11 +2280,10 @@ FORCE_INLINE int _mm_comineq_ss(__m128 a, __m128 b)
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(a));
     uint32x4_t b_not_nan =
         vceqq_f32(vreinterpretq_f32_m128(b), vreinterpretq_f32_m128(b));
-    uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+    uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
     uint32x4_t a_neq_b = vmvnq_u32(
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_neq_b), 0) != 0) ? 1
-                                                                         : 0;
+    return (vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_neq_b), 0) != 0) ? 1 : 0;
 }
 
 // according to the documentation, these intrinsics behave the same as the

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2389,38 +2389,21 @@ public:
             break;
         case IT_MM_COMILT_SS:
             ret = test_mm_comilt_ss(mTestFloatPointer1, mTestFloatPointer2);
-            if (!ret) {
-                // FIXME: incomplete
-                ret = test_mm_comilt_ss(mTestFloatPointer1, mTestFloatPointer2);
-            }
             break;
         case IT_MM_COMIGT_SS:
             ret = test_mm_comigt_ss(mTestFloatPointer1, mTestFloatPointer2);
             break;
         case IT_MM_COMILE_SS:
             ret = test_mm_comile_ss(mTestFloatPointer1, mTestFloatPointer2);
-            if (!ret) {
-                // FIXME: incomplete
-                ret = test_mm_comile_ss(mTestFloatPointer1, mTestFloatPointer2);
-            }
             break;
         case IT_MM_COMIGE_SS:
             ret = test_mm_comige_ss(mTestFloatPointer1, mTestFloatPointer2);
             break;
         case IT_MM_COMIEQ_SS:
             ret = test_mm_comieq_ss(mTestFloatPointer1, mTestFloatPointer2);
-            if (!ret) {
-                // FIXME: incomplete
-                ret = test_mm_comieq_ss(mTestFloatPointer1, mTestFloatPointer2);
-            }
             break;
         case IT_MM_COMINEQ_SS:
             ret = test_mm_comineq_ss(mTestFloatPointer1, mTestFloatPointer2);
-            if (!ret) {
-                // FIXME: incomplete
-                ret =
-                    test_mm_comineq_ss(mTestFloatPointer1, mTestFloatPointer2);
-            }
             break;
         case IT_MM_HADD_PS:
             ret = true;

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -92,12 +92,12 @@ enum InstructionTest {
     IT_MM_MIN_EPI32,      // Unit test *not yet implemented*
     IT_MM_HADD_PS,        // Unit test *not yet implemented*
     IT_MM_CMPORD_PS,      // Unit test *not yet implemented*
-    IT_MM_COMILT_SS,      // Unit test *not yet implemented*
-    IT_MM_COMIGT_SS,      // Unit test *not yet implemented*
-    IT_MM_COMILE_SS,      // Unit test *not yet implemented*
-    IT_MM_COMIGE_SS,      // Unit test *not yet implemented*
-    IT_MM_COMIEQ_SS,      // Unit test *not yet implemented*
-    IT_MM_COMINEQ_SS,     // Unit test *not yet implemented*
+    IT_MM_COMILT_SS,      // Unit test implemented
+    IT_MM_COMIGT_SS,      // Unit test implemented
+    IT_MM_COMILE_SS,      // Unit test implemented
+    IT_MM_COMIGE_SS,      // Unit test implemented
+    IT_MM_COMIEQ_SS,      // Unit test implemented
+    IT_MM_COMINEQ_SS,     // Unit test implemented
     IT_MM_CVTSI128_SI32,  // Unit test *not yet implemented*
     IT_MM_CVTSI32_SI128,  // Unit test *not yet implemented*
     IT_MM_CASTPS_SI128,   // Unit test *not yet implemented*


### PR DESCRIPTION
The result of comparing with NaN is called unordered.
It is different from equal, greater than or less than.

The commit returns the correct value of the single-precision
floating-point comparison instructions when the comparison result
is unordered.

Close #12.