### PR TITLE
Finish integer intrinsics, other improvements

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1726,26 +1726,108 @@ FORCE_INLINE __m128i _mm_adds_epu16(__m128i a, __m128i b)
         vqaddq_u16(vreinterpretq_u16_m128i(a), vreinterpretq_u16_m128i(b)));
 }
 
-FORCE_INLINE __m128i _mm_sign_epi32(__m128i a, __m128i b)
+
+// Negate packed 8-bit integers in a when the corresponding signed
+// 8-bit integer in b is negative, and store the results in dst.
+// Element in dst are zeroed out when the corresponding element
+// in b is zero.
+//
+//   for i in 0..15
+//     if b[i] < 0
+//       r[i] := -a[i]
+//     else if b[i] == 0
+//       r[i] := 0
+//     else
+//       r[i] := a[i]
+//     fi
+//   done
+FORCE_INLINE __m128i _mm_sign_epi8(__m128i _a, __m128i _b)
 {
-    __m128i zer0 = vdupq_n_s32(0);
-    __m128i ltMask = vreinterpretq_s32_u32(vcltq_s32(b, zer0));
-    __m128i gtMask = vreinterpretq_s32_u32(vcgtq_s32(b, zer0));
-    __m128i neg = vnegq_s32(a);
-    __m128i tmp = vandq_s32(a, gtMask);
-    return vorrq_s32(tmp, vandq_s32(neg, ltMask));
+    int8x16_t a = vreinterpretq_s8_m128i(_a);
+    int8x16_t b = vreinterpretq_s8_m128i(_b);
+
+    int8x16_t zero = vdupq_n_s8(0);
+    // signed shift right: faster than vclt
+    // (b < 0) ? 0xFF : 0
+    uint8x16_t ltMask = vreinterpretq_u8_s8(vshrq_n_s8(b, 7));
+    // (b == 0) ? 0xFF : 0
+    int8x16_t zeroMask = vreinterpretq_s8_u8(vceqq_s8(b, zero));
+    // -a
+    int8x16_t neg = vnegq_s8(a);
+    // bitwise select either a or neg based on ltMask
+    int8x16_t masked = vbslq_s8(ltMask, a, neg);
+    // res = masked & (~zeroMask)
+    int8x16_t res = vbicq_s8(masked, zeroMask);
+    return vreinterpretq_m128i_s8(res);
 }
 
-FORCE_INLINE __m128i _mm_sign_epi16(__m128i a, __m128i b)
+
+// Negate packed 16-bit integers in a when the corresponding signed
+// 16-bit integer in b is negative, and store the results in dst.
+// Element in dst are zeroed out when the corresponding element
+// in b is zero.
+//
+//   for i in 0..7
+//     if b[i] < 0
+//       r[i] := -a[i]
+//     else if b[i] == 0
+//       r[i] := 0
+//     else
+//       r[i] := a[i]
+//     fi
+//   done
+FORCE_INLINE __m128i _mm_sign_epi16(__m128i _a, __m128i _b)
 {
-    int16x8_t zer0 = vdupq_n_s16(0);
-    int16x8_t ltMask =
-        vreinterpretq_s16_u16(vcltq_s16(vreinterpretq_s16_s32(b), zer0));
-    int16x8_t gtMask =
-        vreinterpretq_s16_u16(vcgtq_s16(vreinterpretq_s16_s32(b), zer0));
-    int16x8_t neg = vnegq_s16(vreinterpretq_s16_s32(a));
-    int16x8_t tmp = vandq_s16(vreinterpretq_s16_s32(a), gtMask);
-    return vreinterpretq_s32_s16(vorrq_s16(tmp, vandq_s16(neg, ltMask)));
+    int16x8_t a = vreinterpretq_s16_m128i(_a);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
+
+    int16x8_t zero = vdupq_n_s16(0);
+    // signed shift right: faster than vclt
+    // (b < 0) ? 0xFFFF : 0
+    uint16x8_t ltMask = vreinterpretq_u16_s16(vshrq_n_s16(b, 15));
+    // (b == 0) ? 0xFFFF : 0
+    int16x8_t zeroMask = vreinterpretq_s16_u16(vceqq_s16(b, zero));
+    // -a
+    int16x8_t neg = vnegq_s16(a);
+    // bitwise select either a or neg based on ltMask
+    int16x8_t masked = vbslq_s16(ltMask, a, neg);
+    // res = masked & (~zeroMask)
+    int16x8_t res = vbicq_s16(masked, zeroMask);
+    return vreinterpretq_m128i_s16(res);
+}
+
+// Negate packed 32-bit integers in a when the corresponding signed
+// 32-bit integer in b is negative, and store the results in dst.
+// Element in dst are zeroed out when the corresponding element
+// in b is zero.
+//
+//   for i in 0..3
+//     if b[i] < 0
+//       r[i] := -a[i]
+//     else if b[i] == 0
+//       r[i] := 0
+//     else
+//       r[i] := a[i]
+//     fi
+//   done
+FORCE_INLINE __m128i _mm_sign_epi32(__m128i _a, __m128i _b)
+{
+    int32x4_t a = vreinterpretq_s32_m128i(_a);
+    int32x4_t b = vreinterpretq_s32_m128i(_b);
+
+    int32x4_t zero = vdupq_n_s32(0);
+    // signed shift right: faster than vclt
+    // (b < 0) ? 0xFFFFFFFF : 0
+    uint32x4_t ltMask = vreinterpretq_u32_s32(vshrq_n_s32(b, 31));
+    // (b == 0) ? 0xFFFFFFFF : 0
+    int32x4_t zeroMask = vreinterpretq_s32_u32(vceqq_s32(b, zero));
+    // neg = -a
+    int32x4_t neg = vnegq_s32(a);
+    // bitwise select either a or neg based on ltMask
+    int32x4_t masked = vbslq_s32(ltMask, a, neg);
+    // res = masked & (~zeroMask)
+    int32x4_t res = vbicq_s32(masked, zeroMask);
+    return vreinterpretq_m128i_s32(res);
 }
 
 // Adds the four single-precision, floating-point values of a and b.

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1018,45 +1018,25 @@ FORCE_INLINE __m128i _mm_shuffle_epi_3332(__m128i a)
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_shuffle_epi8&expand=5146
 FORCE_INLINE __m128i _mm_shuffle_epi8(__m128i a, __m128i b)
 {
-#if __aarch64__
     int8x16_t tbl = vreinterpretq_s8_m128i(a);   // input a
     uint8x16_t idx = vreinterpretq_u8_m128i(b);  // input b
-    uint8_t __attribute__((aligned(16)))
-    mask[16] = {0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F,
-                0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F};
     uint8x16_t idx_masked =
-        vandq_u8(idx, vld1q_u8(mask));  // avoid using meaningless bits
-
+        vandq_u8(idx, vdupq_n_u8(0x8F));  // avoid using meaningless bits
+#if defined(__aarch64__)
     return vreinterpretq_m128i_s8(vqtbl1q_s8(tbl, idx_masked));
 #else
-    uint8_t *tbl = (uint8_t *) &a;  // input a
-    uint8_t *idx = (uint8_t *) &b;  // input b
-    int32_t r[4];
-
-    r[0] = ((idx[3] & 0x80) ? 0 : tbl[idx[3] % 16]) << 24;
-    r[0] |= ((idx[2] & 0x80) ? 0 : tbl[idx[2] % 16]) << 16;
-    r[0] |= ((idx[1] & 0x80) ? 0 : tbl[idx[1] % 16]) << 8;
-    r[0] |= ((idx[0] & 0x80) ? 0 : tbl[idx[0] % 16]);
-
-    r[1] = ((idx[7] & 0x80) ? 0 : tbl[idx[7] % 16]) << 24;
-    r[1] |= ((idx[6] & 0x80) ? 0 : tbl[idx[6] % 16]) << 16;
-    r[1] |= ((idx[5] & 0x80) ? 0 : tbl[idx[5] % 16]) << 8;
-    r[1] |= ((idx[4] & 0x80) ? 0 : tbl[idx[4] % 16]);
-
-    r[2] = ((idx[11] & 0x80) ? 0 : tbl[idx[11] % 16]) << 24;
-    r[2] |= ((idx[10] & 0x80) ? 0 : tbl[idx[10] % 16]) << 16;
-    r[2] |= ((idx[9] & 0x80) ? 0 : tbl[idx[9] % 16]) << 8;
-    r[2] |= ((idx[8] & 0x80) ? 0 : tbl[idx[8] % 16]);
-
-    r[3] = ((idx[15] & 0x80) ? 0 : tbl[idx[15] % 16]) << 24;
-    r[3] |= ((idx[14] & 0x80) ? 0 : tbl[idx[14] % 16]) << 16;
-    r[3] |= ((idx[13] & 0x80) ? 0 : tbl[idx[13] % 16]) << 8;
-    r[3] |= ((idx[12] & 0x80) ? 0 : tbl[idx[12] % 16]);
-
-    return vld1q_s32(r);
+    // cast is only well-defined in 32-bit mode.
+    int8x8x2_t a_split = *(int8x8x2_t *)&tbl;
+    // use this line if testing on aarch64
+    // int8x8x2_t a_split = { vget_low_s8(tbl), vget_high_s8(tbl) };
+    return vreinterpretq_m128i_s8(
+        vcombine_s8(
+            vtbl2_s8(a_split, vget_low_u8(idx_masked)),
+            vtbl2_s8(a_split, vget_high_u8(idx_masked))
+        )
+    );
 #endif
 }
-
 
 #if 0 /* C version */
 FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1987,7 +1987,7 @@ FORCE_INLINE __m128i _mm_mul_epi32(__m128i a, __m128i b)
 {
     // vmull_s32 upcasts instead of masking, so we downcast.
     int32x2_t a_lo = vmovn_s64(vreinterpretq_s64_m128i(a));
-    int32x2_t b_lo = vmovn_u64(vreinterpretq_s64_m128i(b));
+    int32x2_t b_lo = vmovn_s64(vreinterpretq_s64_m128i(b));
     return vreinterpretq_m128i_s64(vmull_s32(a_lo, b_lo));
 }
 

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2462,10 +2462,14 @@ FORCE_INLINE __m128i _mm_packs_epi32(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/xf7k860c%28v=vs.90%29.aspx
 FORCE_INLINE __m128i _mm_unpacklo_epi8(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s8(vzip1q_s8(vreinterpretq_s8_m128i(a), vreinterpretq_s8_m128i(b)));
+#else
     int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(vreinterpretq_s16_m128i(a)));
     int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(vreinterpretq_s16_m128i(b)));
     int8x8x2_t result = vzip_s8(a1, b1);
     return vreinterpretq_m128i_s8(vcombine_s8(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the lower 4 signed or unsigned 16-bit integers in a with the
@@ -2483,10 +2487,14 @@ FORCE_INLINE __m128i _mm_unpacklo_epi8(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/btxb17bw%28v=vs.90%29.aspx
 FORCE_INLINE __m128i _mm_unpacklo_epi16(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s16(vzip1q_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+#else
     int16x4_t a1 = vget_low_s16(vreinterpretq_s16_m128i(a));
     int16x4_t b1 = vget_low_s16(vreinterpretq_s16_m128i(b));
     int16x4x2_t result = vzip_s16(a1, b1);
     return vreinterpretq_m128i_s16(vcombine_s16(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the lower 2 signed or unsigned 32 - bit integers in a with the
@@ -2500,10 +2508,14 @@ FORCE_INLINE __m128i _mm_unpacklo_epi16(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/x8atst9d(v=vs.100).aspx
 FORCE_INLINE __m128i _mm_unpacklo_epi32(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s32(vzip1q_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+#else
     int32x2_t a1 = vget_low_s32(vreinterpretq_s32_m128i(a));
     int32x2_t b1 = vget_low_s32(vreinterpretq_s32_m128i(b));
     int32x2x2_t result = vzip_s32(a1, b1);
     return vreinterpretq_m128i_s32(vcombine_s32(result.val[0], result.val[1]));
+#endif
 }
 
 FORCE_INLINE __m128i _mm_unpacklo_epi64(__m128i a, __m128i b)
@@ -2524,10 +2536,14 @@ FORCE_INLINE __m128i _mm_unpacklo_epi64(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/25st103b%28v=vs.90%29.aspx
 FORCE_INLINE __m128 _mm_unpacklo_ps(__m128 a, __m128 b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128_f32(vzip1q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+#else
     float32x2_t a1 = vget_low_f32(vreinterpretq_f32_m128(a));
     float32x2_t b1 = vget_low_f32(vreinterpretq_f32_m128(b));
     float32x2x2_t result = vzip_f32(a1, b1);
     return vreinterpretq_m128_f32(vcombine_f32(result.val[0], result.val[1]));
+#endif
 }
 
 // Selects and interleaves the upper two single-precision, floating-point values
@@ -2541,10 +2557,14 @@ FORCE_INLINE __m128 _mm_unpacklo_ps(__m128 a, __m128 b)
 // https://msdn.microsoft.com/en-us/library/skccxx7d%28v=vs.90%29.aspx
 FORCE_INLINE __m128 _mm_unpackhi_ps(__m128 a, __m128 b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128_f32(vzip2q_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
+#else
     float32x2_t a1 = vget_high_f32(vreinterpretq_f32_m128(a));
     float32x2_t b1 = vget_high_f32(vreinterpretq_f32_m128(b));
     float32x2x2_t result = vzip_f32(a1, b1);
     return vreinterpretq_m128_f32(vcombine_f32(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the upper 8 signed or unsigned 8-bit integers in a with the upper
@@ -2561,12 +2581,16 @@ FORCE_INLINE __m128 _mm_unpackhi_ps(__m128 a, __m128 b)
 // https://msdn.microsoft.com/en-us/library/t5h7783k(v=vs.100).aspx
 FORCE_INLINE __m128i _mm_unpackhi_epi8(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s8(vzip2q_s8(vreinterpretq_s8_m128i(a), vreinterpretq_s8_m128i(b)));
+#else
     int8x8_t a1 =
         vreinterpret_s8_s16(vget_high_s16(vreinterpretq_s16_m128i(a)));
     int8x8_t b1 =
         vreinterpret_s8_s16(vget_high_s16(vreinterpretq_s16_m128i(b)));
     int8x8x2_t result = vzip_s8(a1, b1);
     return vreinterpretq_m128i_s8(vcombine_s8(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the upper 4 signed or unsigned 16-bit integers in a with the
@@ -2584,10 +2608,14 @@ FORCE_INLINE __m128i _mm_unpackhi_epi8(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/03196cz7(v=vs.100).aspx
 FORCE_INLINE __m128i _mm_unpackhi_epi16(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s16(vzip2q_s16(vreinterpretq_s16_m128i(a), vreinterpretq_s16_m128i(b)));
+#else
     int16x4_t a1 = vget_high_s16(vreinterpretq_s16_m128i(a));
     int16x4_t b1 = vget_high_s16(vreinterpretq_s16_m128i(b));
     int16x4x2_t result = vzip_s16(a1, b1);
     return vreinterpretq_m128i_s16(vcombine_s16(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the upper 2 signed or unsigned 32-bit integers in a with the
@@ -2595,10 +2623,14 @@ FORCE_INLINE __m128i _mm_unpackhi_epi16(__m128i a, __m128i b)
 // https://msdn.microsoft.com/en-us/library/65sa7cbs(v=vs.100).aspx
 FORCE_INLINE __m128i _mm_unpackhi_epi32(__m128i a, __m128i b)
 {
+#if defined(__aarch64__)
+    return vreinterpretq_m128i_s32(vzip2q_s32(vreinterpretq_s32_m128i(a), vreinterpretq_s32_m128i(b)));
+#else
     int32x2_t a1 = vget_high_s32(vreinterpretq_s32_m128i(a));
     int32x2_t b1 = vget_high_s32(vreinterpretq_s32_m128i(b));
     int32x2x2_t result = vzip_s32(a1, b1);
     return vreinterpretq_m128i_s32(vcombine_s32(result.val[0], result.val[1]));
+#endif
 }
 
 // Interleaves the upper signed or unsigned 64-bit integer in a with the

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2650,10 +2650,7 @@ FORCE_INLINE __m128i _mm_unpackhi_epi64(__m128i a, __m128i b)
 // shift to right
 // https://msdn.microsoft.com/en-us/library/bb514041(v=vs.120).aspx
 // http://blog.csdn.net/hemmingway/article/details/44828303
-FORCE_INLINE __m128i _mm_alignr_epi8(__m128i a, __m128i b, const int c)
-{
-    return (__m128i) vextq_s8((int8x16_t) a, (int8x16_t) b, c);
-}
+#define _mm_alignr_epi8(a, b, c) ((__m128i) vextq_s8((int8x16_t) (a), (int8x16_t) (b), (c))
 
 // Extracts the selected signed or unsigned 16-bit integer from a and zero
 // extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1978,6 +1978,20 @@ FORCE_INLINE __m128i _mm_mul_epu32(__m128i a, __m128i b)
     return vreinterpretq_m128i_u64(vmull_u32(a_lo, b_lo));
 }
 
+// Multiply the low signed 32-bit integers from each packed 64-bit element in
+// a and b, and store the signed 64-bit results in dst.
+//
+//   r0 :=  (int64_t)(int32_t)a0 * (int64_t)(int32_t)b0
+//   r1 :=  (int64_t)(int32_t)a2 * (int64_t)(int32_t)b2
+FORCE_INLINE __m128i _mm_mul_epi32(__m128i a, __m128i b)
+{
+    // vmull_s32 upcasts instead of masking, so we downcast.
+    int32x2_t a_lo = vmovn_s64(vreinterpretq_s64_m128i(a));
+    int32x2_t b_lo = vmovn_u64(vreinterpretq_s64_m128i(b));
+    return vreinterpretq_m128i_s64(vmull_s32(a_lo, b_lo));
+}
+
+
 // Multiplies the 8 signed 16-bit integers from a by the 8 signed 16-bit
 // integers from b.
 //

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1257,164 +1257,7 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
         uint16x8_t _b = vreinterpretq_m128i_u16(b);      \
         vreinterpretq_u16_m128i(vbslq_u16(_b, _a, _mask_vec)); \
     })
-// Shifts the 4 signed 32-bit integers in a right by count bits while shifting
-// in the sign bit.
-//
-//   r0 := a0 >> count
-//   r1 := a1 >> count
-//   r2 := a2 >> count
-//   r3 := a3 >> count immediate
-FORCE_INLINE __m128i _mm_srai_epi32(__m128i a, int count)
-{
-    return vshlq_s32(a, vdupq_n_s32(-count));
-}
 
-// Shifts the 8 signed 16-bit integers in a right by count bits while shifting
-// in the sign bit.
-//
-//   r0 := a0 >> count
-//   r1 := a1 >> count
-//   ...
-//   r7 := a7 >> count
-FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int count)
-{
-    return (__m128i) vshlq_s16((int16x8_t) a, vdupq_n_s16(-count));
-}
-
-// Shifts the 8 signed or unsigned 16-bit integers in a left by count bits while
-// shifting in zeros.
-//
-//   r0 := a0 << count
-//   r1 := a1 << count
-//   ...
-//   r7 := a7 << count
-//
-// https://msdn.microsoft.com/en-us/library/es73bcsy(v=vs.90).aspx
-#define _mm_slli_epi16(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_s16(                       \
-                vshlq_n_s16(vreinterpretq_s16_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shifts the 4 signed or unsigned 32-bit integers in a left by count bits while
-// shifting in zeros. :
-// https://msdn.microsoft.com/en-us/library/z2k3bbtb%28v=vs.90%29.aspx
-// FORCE_INLINE __m128i _mm_slli_epi32(__m128i a, __constrange(0,255) int imm)
-#define _mm_slli_epi32(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_s32(                       \
-                vshlq_n_s32(vreinterpretq_s32_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and
-// store the results in dst.
-#define _mm_slli_epi64(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 63) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_s64(                       \
-                vshlq_n_s64(vreinterpretq_s64_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shifts the 8 signed or unsigned 16-bit integers in a right by count bits
-// while shifting in zeros.
-//
-//   r0 := srl(a0, count)
-//   r1 := srl(a1, count)
-//   ...
-//   r7 := srl(a7, count)
-//
-// https://msdn.microsoft.com/en-us/library/6tcwd38t(v=vs.90).aspx
-#define _mm_srli_epi16(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_u16(                       \
-                vshrq_n_u16(vreinterpretq_u16_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shifts the 4 signed or unsigned 32-bit integers in a right by count bits
-// while shifting in zeros.
-// https://msdn.microsoft.com/en-us/library/w486zcfa(v=vs.100).aspx FORCE_INLINE
-// __m128i _mm_srli_epi32(__m128i a, __constrange(0,255) int imm)
-#define _mm_srli_epi32(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_u32(                       \
-                vshrq_n_u32(vreinterpretq_u32_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shift packed 64-bit integers in a right by imm8 while shifting in zeros, and
-// store the results in dst.
-#define _mm_srli_epi64(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 63) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_u64(                       \
-                vshrq_n_u64(vreinterpretq_u64_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
-
-// Shifts the 4 signed 32 - bit integers in a right by count bits while shifting
-// in the sign bit.
-// https://msdn.microsoft.com/en-us/library/z1939387(v=vs.100).aspx
-// FORCE_INLINE __m128i _mm_srai_epi32(__m128i a, __constrange(0,255) int imm)
-#define _mm_srai_epi32(a, imm)                                   \
-    ({                                                           \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = vreinterpretq_m128i_s32(                       \
-                vshrq_n_s32(vreinterpretq_s32_m128i(a), 16));    \
-            ret = vreinterpretq_m128i_s32(                       \
-                vshrq_n_s32(vreinterpretq_s32_m128i(ret), 16));  \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_s32(                       \
-                vshrq_n_s32(vreinterpretq_s32_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
 
 // Shifts the 128 - bit value in a right by imm bytes while shifting in
 // zeros.imm must be an immediate.
@@ -1457,6 +1300,287 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int count)
         }                                                               \
         ret;                                                            \
     })
+
+// Shifts the 8 signed 16-bit integers right by count bits while shifting
+// in the sign bit.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+//   r2 := a2 >> count
+//   ...
+//   r7 := a8 >> count immediate
+FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int count)
+{
+    return (__m128i) vshlq_s16((int16x8_t) a, vdupq_n_s16(-(count & 0xff)));
+}
+
+// Shifts the 4 signed 32-bit integers right by count bits while shifting
+// in the sign bit.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+//   r2 := a2 >> count
+//   r3 := a3 >> count immediate
+FORCE_INLINE __m128i _mm_srai_epi32(__m128i a, int count)
+{
+    return vshlq_s32(a, vdupq_n_s32(-(count & 0xff)));
+}
+
+// Shifts the 2 signed 64-bit integers right by count bits while shifting
+// in the sign bit.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+FORCE_INLINE __m128i _mm_srai_epi64(__m128i a, int count)
+{
+    return (__m128i) vshlq_s64((int64x2_t) a, vdupq_n_s64(-(count & 0xff)));
+}
+
+// Shifts the 8 signed or unsigned 16-bit integers left by count bits
+//
+//   r0 := a0 << count
+//   r1 := a1 << count
+//   ...
+//   r7 := a7 << count
+FORCE_INLINE __m128i _mm_slli_epi16(__m128i a, int count)
+{
+    return (__m128i) vshlq_s16((int16x8_t) a, vdupq_n_s16(count & 0xff));
+}
+
+// Shifts the 4 signed or unsigned 32-bit integers left by count bits
+//
+//   r0 := a0 << count
+//   r1 := a1 << count
+//   r2 := a2 << count
+//   r3 := a3 << count
+FORCE_INLINE __m128i _mm_slli_epi32(__m128i a, int count)
+{
+    return (__m128i) vshlq_s32((int32x4_t) a, vdupq_n_s32(count & 0xff));
+}
+
+// Shifts the 2 signed or unsigned 64-bit integers left by count bits
+//
+//   r0 := a0 << count
+//   r1 := a1 << count
+FORCE_INLINE __m128i _mm_slli_epi64(__m128i a, int count)
+{
+    return (__m128i) vshlq_s64((int64x2_t) a, vdupq_n_s64(count & 0xff));
+}
+
+
+// Shifts the 8 unsigned 16-bit integers right by count bits while shifting
+// in zeroes.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+//   r2 := a2 >> count
+//   ...
+//   r7 := a8 >> count immediate
+FORCE_INLINE __m128i _mm_srli_epi16(__m128i a, int count)
+{
+    return (__m128i) vshlq_u16((uint16x8_t) a, vdupq_n_s16(-(count & 0xff)));
+}
+
+// Shifts the 4 unsigned 32-bit integers right by count bits while shifting
+// in zeroes.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+//   r2 := a2 >> count
+//   r3 := a3 >> count immediate
+FORCE_INLINE __m128i _mm_srli_epi32(__m128i a, int count)
+{
+    return (__m128i) vshlq_u32((uint32x4_t) a, vdupq_n_s32(-(count & 0xff)));
+}
+
+// Shifts the 2 unsigned 64-bit integers right by count bits while shifting
+// in zeroes.
+//
+//   r0 := a0 >> count
+//   r1 := a1 >> count
+FORCE_INLINE __m128i _mm_srli_epi64(__m128i a, int count)
+{
+    return (__m128i) vshlq_u64((uint64x2_t) a, vdupq_n_s64(-(count & 0xff)));
+}
+
+FORCE_INLINE __m128i _mm_sllv_epi16(__m128i _a, __m128i _b)
+{
+    uint16x8_t a = vreinterpretq_u16_m128i(_a);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
+    // NEON and SSE both use zero on > 15, but NEON can't be
+    // negative or it will shift right.
+    int16x8_t mask = vandq_s16(b, vdupq_n_s16(0x7fff));
+    return vreinterpretq_m128i_u16(vshlq_u16(a, mask));
+}
+
+FORCE_INLINE __m128i _mm_sllv_epi32(__m128i _a, __m128i _b)
+{
+    uint32x4_t a = vreinterpretq_u32_m128i(_a);
+    int32x4_t b = vreinterpretq_s32_m128i(_b);
+    // NEON and SSE both use zero on > 31, but NEON can't be
+    // negative or it will shift right.
+    int32x4_t mask = vandq_s32(b, vdupq_n_s32(0x7fffffff));
+    return vreinterpretq_m128i_u32(vshlq_u32(a, mask));
+}
+
+
+FORCE_INLINE __m128i _mm_sllv_epi64(__m128i _a, __m128i _b)
+{
+    uint64x2_t a = vreinterpretq_u64_m128i(_a);
+    int64x2_t b = vreinterpretq_s64_m128i(_b);
+    // NEON and SSE both use zero on > 63, but NEON can't be
+    // negative or it will shift right.
+    int64x2_t mask = vandq_s64(b, vdupq_n_s64(0x7fffffffffffffff));
+    return vreinterpretq_m128i_u64(vshlq_u64(a, mask));
+}
+
+FORCE_INLINE __m128i _mm_sll_epi16(__m128i a, __m128i b)
+{
+    int16x8_t duped =
+       vdupq_lane_s16(
+          vget_low_s16(vreinterpretq_s16_m128i(b)), 0
+       );
+    return _mm_sllv_epi16(a, vreinterpretq_m128i_s16(duped));
+}
+
+FORCE_INLINE __m128i _mm_sll_epi32(__m128i a, __m128i b)
+{
+    int32x4_t duped =
+       vdupq_lane_s32(
+          vget_low_s32(vreinterpretq_s32_m128i(b)), 0
+       );
+    return _mm_sllv_epi32(a, vreinterpretq_m128i_s32(duped));
+}
+
+FORCE_INLINE __m128i _mm_sll_epi64(__m128i a, __m128i b)
+{
+    int64x2_t duped =
+       vdupq_lane_s64(
+          vget_low_s64(vreinterpretq_s64_m128i(b)), 0
+       );
+    return _mm_sllv_epi64(a, vreinterpretq_m128i_s64(duped));
+}
+
+FORCE_INLINE __m128i _mm_srlv_epi16(__m128i _a, __m128i _b)
+{
+    uint16x8_t a = vreinterpretq_u16_m128i(_a);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
+    // NEON and SSE both use zero on > 15, but NEON can't be
+    // negative or it will shift left.
+    int16x8_t mask = vandq_s16(b, vdupq_n_s16(0x7fff));
+    int16x8_t reversed = vnegq_s16(mask);
+    return vreinterpretq_m128i_u16(vshlq_u16(a, reversed));
+}
+
+FORCE_INLINE __m128i _mm_srlv_epi32(__m128i _a, __m128i _b)
+{
+    uint32x4_t a = vreinterpretq_u32_m128i(_a);
+    int32x4_t b = vreinterpretq_s32_m128i(_b);
+    // NEON and SSE both use zero on > 31, but NEON can't be
+    // negative or it will shift left.
+    int32x4_t mask = vandq_s32(b, vdupq_n_s32(0x7fffffff));
+    int32x4_t reversed = vnegq_s32(mask);
+    return vreinterpretq_m128i_u32(vshlq_u32(a, reversed));
+}
+
+FORCE_INLINE __m128i _mm_srlv_epi64(__m128i _a, __m128i _b)
+{
+    uint64x2_t a = vreinterpretq_u64_m128i(_a);
+    int64x2_t b = vreinterpretq_s64_m128i(_b);
+    // NEON and SSE both use zero on > 63, but NEON can't be
+    // negative or it will shift right.
+    int64x2_t mask = vandq_s64(b, vdupq_n_s64(0x7fffffffffffffff));
+    int64x2_t reversed = vsubq_s64(vdupq_n_s64(0), mask);
+    return vreinterpretq_m128i_u64(vshlq_u64(a, reversed));
+}
+
+
+FORCE_INLINE __m128i _mm_srl_epi16(__m128i a, __m128i b)
+{
+    int16x8_t duped =
+       vdupq_lane_s16(
+          vget_low_s16(vreinterpretq_s16_m128i(b)), 0
+       );
+    return _mm_srlv_epi16(a, vreinterpretq_m128i_s16(duped));
+}
+
+FORCE_INLINE __m128i _mm_srl_epi32(__m128i a, __m128i b)
+{
+    int32x4_t duped =
+       vdupq_lane_s32(
+          vget_low_s32(vreinterpretq_s32_m128i(b)), 0
+       );
+    return _mm_srlv_epi32(a, vreinterpretq_m128i_s32(duped));
+}
+
+FORCE_INLINE __m128i _mm_srl_epi64(__m128i a, __m128i b)
+{
+    int64x2_t duped =
+       vdupq_lane_s64(
+          vget_low_s64(vreinterpretq_s64_m128i(b)), 0
+       );
+    return _mm_srlv_epi64(a, vreinterpretq_m128i_s64(duped));
+}
+
+FORCE_INLINE __m128i _mm_srav_epi16(__m128i _a, __m128i _b)
+{
+    int16x8_t a = vreinterpretq_s16_m128i(_a);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
+    // NEON and SSE both use zero on > 15, but NEON can't be
+    // negative or it will shift left.
+    int16x8_t mask = vandq_s16(b, vdupq_n_s16(0x7fff));
+    int16x8_t reversed = vnegq_s16(mask);
+    return vreinterpretq_m128i_s16(vshlq_s16(a, reversed));
+}
+
+FORCE_INLINE __m128i _mm_srav_epi32(__m128i _a, __m128i _b)
+{
+    int32x4_t a = vreinterpretq_s32_m128i(_a);
+    int32x4_t b = vreinterpretq_s32_m128i(_b);
+    // NEON and SSE both use zero on > 31, but NEON can't be
+    // negative or it will shift left.
+    int32x4_t mask = vandq_s32(b, vdupq_n_s32(0x7fffffff));
+    int32x4_t reversed = vnegq_s32(mask);
+    return vreinterpretq_m128i_s32(vshlq_s32(a, reversed));
+}
+
+FORCE_INLINE __m128i _mm_srav_epi64(__m128i _a, __m128i _b)
+{
+    int64x2_t a = vreinterpretq_s64_m128i(_a);
+    int64x2_t b = vreinterpretq_s64_m128i(_b);
+    // NEON and SSE both use zero on > 63, but NEON can't be
+    // negative or it will shift right.
+    int64x2_t mask = vandq_s64(b, vdupq_n_s64(0x7fffffffffffffff));
+    int64x2_t reversed = vsubq_s64(vdupq_n_s64(0), mask);
+    return vreinterpretq_m128i_s64(vshlq_s64(a, reversed));
+}
+
+FORCE_INLINE __m128i _mm_sra_epi16(__m128i a, __m128i b)
+{
+    int16x8_t duped =
+       vdupq_lane_s16(
+          vget_low_s16(vreinterpretq_s16_m128i(b)), 0
+       );
+    return _mm_srav_epi16(a, vreinterpretq_m128i_s16(duped));
+}
+
+FORCE_INLINE __m128i _mm_sra_epi32(__m128i a, __m128i b)
+{
+    int32x4_t duped =
+       vdupq_lane_s32(
+          vget_low_s32(vreinterpretq_s32_m128i(b)), 0
+       );
+    return _mm_srav_epi32(a, vreinterpretq_m128i_s32(duped));
+}
+
+FORCE_INLINE __m128i _mm_sra_epi64(__m128i a, __m128i b)
+{
+    int64x2_t duped =
+       vdupq_lane_s64(
+          vget_low_s64(vreinterpretq_s64_m128i(b)), 0
+       );
+    return _mm_srav_epi64(a, vreinterpretq_m128i_s64(duped));
+}
 
 // NEON does not provide a version of this function.
 // Creates a 16-bit mask from the most significant bits of the 16 signed or

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -400,14 +400,14 @@ FORCE_INLINE __m128i _mm_set1_epi32(int _i)
 }
 
 // Sets the 2 signed 64-bit integer values to i.
-// https://msdn.microsoft.com/en-us/library/vstudio/h4xscxat(v=vs.100).aspx
+// https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2010/whtfzhzk(v=vs.100)
 FORCE_INLINE __m128i _mm_set1_epi64(int64_t _i)
 {
     return vreinterpretq_m128i_s64(vdupq_n_s64(_i));
 }
 
 // Sets the 2 signed 64-bit integer values to i.
-// https://msdn.microsoft.com/en-us/library/vstudio/h4xscxat(v=vs.100).aspx
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_set1_epi64x&expand=4961
 FORCE_INLINE __m128i _mm_set1_epi64x(int64_t _i)
 {
     return vreinterpretq_m128i_s64(vdupq_n_s64(_i));

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1240,6 +1240,23 @@ FORCE_INLINE __m128i _mm_shuffle_epi32_default(__m128i a,
 #define _mm_shufflehi_epi16(a, imm) _mm_shufflehi_epi16_function((a), (imm))
 #endif
 
+#define _mm_blend_epi16(a, b, imm)                       \
+    ({                                                   \
+        static const uint16_t _mask[8] = {               \
+            ((imm) & 0x1) * 0xFFFF,                      \
+            (((imm) >> 1) & 0x1) * 0xFFFF,               \
+            (((imm) >> 2) & 0x1) * 0xFFFF,               \
+            (((imm) >> 3) & 0x1) * 0xFFFF,               \
+            (((imm) >> 4) & 0x1) * 0xFFFF,               \
+            (((imm) >> 5) & 0x1) * 0xFFFF,               \
+            (((imm) >> 6) & 0x1) * 0xFFFF,               \
+            (((imm) >> 7) & 0x1) * 0xFFFF                \
+        };                                               \
+        uint16x8_t _mask_vec = vld1q_u16(_mask);         \
+        uint16x8_t _a = vreinterpretq_m128i_u16(a);      \
+        uint16x8_t _b = vreinterpretq_m128i_u16(b);      \
+        vreinterpretq_u16_m128i(vbslq_u16(_b, _a, _mask_vec)); \
+    })
 // Shifts the 4 signed 32-bit integers in a right by count bits while shifting
 // in the sign bit.
 //
@@ -2684,7 +2701,7 @@ FORCE_INLINE __m128i _mm_unpackhi_epi64(__m128i a, __m128i b)
 // shift to right
 // https://msdn.microsoft.com/en-us/library/bb514041(v=vs.120).aspx
 // http://blog.csdn.net/hemmingway/article/details/44828303
-#define _mm_alignr_epi8(a, b, c) ((__m128i) vextq_s8((int8x16_t) (a), (int8x16_t) (b), (c))
+#define _mm_alignr_epi8(a, b, c) ((__m128i) vextq_s8((int8x16_t) (b), (int8x16_t) (a), (c)))
 
 // Extracts the selected signed or unsigned 16-bit integer from a and zero
 // extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -202,6 +202,7 @@ FORCE_INLINE uint8x16x4_t vld1q_u8_x4(const uint8_t *p)
 // processor. https://msdn.microsoft.com/en-us/library/84szxsww(v=vs.100).aspx
 FORCE_INLINE void _mm_prefetch(const void *p, int i)
 {
+    (void)i;
     __builtin_prefetch(p);
 }
 
@@ -3473,6 +3474,7 @@ FORCE_INLINE void _mm_stream_si128(__m128i *p, __m128i a)
 // https://msdn.microsoft.com/en-us/library/ba08y07y(v=vs.100).aspx
 FORCE_INLINE void _mm_clflush(void const *p)
 {
+    (void)p;
     // no corollary for Neon?
 }
 

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2917,11 +2917,27 @@ FORCE_INLINE __m128i _mm_unpackhi_epi64(__m128i a, __m128i b)
 // http://blog.csdn.net/hemmingway/article/details/44828303
 #define _mm_alignr_epi8(a, b, c) ((__m128i) vextq_s8((int8x16_t) (b), (int8x16_t) (a), (c)))
 
+// Extracts the selected signed or unsigned 8-bit integer from a and zero
+// extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx
+// FORCE_INLINE int _mm_extract_epi8(__m128i a, __constrange(0,16) int imm)
+#define _mm_extract_epi8(a, imm) \
+    vgetq_lane_u8(vreinterpretq_u8_m128i(a), (imm))
+
+// Inserts the least significant 8 bits of b into the selected 16-bit integer
+// of a. https://msdn.microsoft.com/en-us/library/kaze8hz1%28v=vs.100%29.aspx
+// FORCE_INLINE __m128i _mm_insert_epi8(__m128i a, const int b,
+// __constrange(0,16) int imm)
+#define _mm_insert_epi8(a, b, imm)                                  \
+    ({                                                               \
+        vreinterpretq_m128i_s8(                                     \
+            vsetq_lane_s8((b), vreinterpretq_s8_m128i(a), (imm))); \
+    })
+
 // Extracts the selected signed or unsigned 16-bit integer from a and zero
 // extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx
 // FORCE_INLINE int _mm_extract_epi16(__m128i a, __constrange(0,8) int imm)
 #define _mm_extract_epi16(a, imm) \
-    ({ (vgetq_lane_s16(vreinterpretq_s16_m128i(a), (imm)) & 0x0000ffffUL); })
+    vgetq_lane_u16(vreinterpretq_u16_m128i(a), (imm))
 
 // Inserts the least significant 16 bits of b into the selected 16-bit integer
 // of a. https://msdn.microsoft.com/en-us/library/kaze8hz1%28v=vs.100%29.aspx
@@ -2931,6 +2947,39 @@ FORCE_INLINE __m128i _mm_unpackhi_epi64(__m128i a, __m128i b)
     ({                                                               \
         vreinterpretq_m128i_s16(                                     \
             vsetq_lane_s16((b), vreinterpretq_s16_m128i(a), (imm))); \
+    })
+
+// Extracts the selected signed or unsigned 32-bit integer from a and zero
+// extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx
+// FORCE_INLINE int _mm_extract_epi32(__m128i a, __constrange(0,4) int imm)
+#define _mm_extract_epi32(a, imm) \
+    vgetq_lane_s32(vreinterpretq_s32_m128i(a), (imm))
+
+// Inserts the least significant 32 bits of b into the selected 32-bit integer
+// of a. https://msdn.microsoft.com/en-us/library/kaze8hz1%28v=vs.100%29.aspx
+// FORCE_INLINE __m128i _mm_insert_epi32(__m128i a, const int b,
+// __constrange(0,4) int imm)
+#define _mm_insert_epi32(a, b, imm)                                  \
+    ({                                                               \
+        vreinterpretq_m128i_s32(                                     \
+            vsetq_lane_s32((b), vreinterpretq_s32_m128i(a), (imm))); \
+    })
+
+
+// Extracts the selected signed or unsigned 64-bit integer from a and zero
+// extends.  https://msdn.microsoft.com/en-us/library/6dceta0c(v=vs.100).aspx
+// FORCE_INLINE __int64 _mm_extract_epi64(__m128i a, __constrange(0,2) int imm)
+#define _mm_extract_epi64(a, imm) \
+    vgetq_lane_s64(vreinterpretq_s64_m128i(a), (imm))
+
+// Inserts the least significant 64 bits of b into the selected 64-bit integer
+// of a. https://msdn.microsoft.com/en-us/library/kaze8hz1%28v=vs.100%29.aspx
+// FORCE_INLINE __m128i _mm_insert_epi64(__m128i a, const __int64 b,
+// __constrange(0,2) int imm)
+#define _mm_insert_epi64(a, b, imm)                                  \
+    ({                                                               \
+        vreinterpretq_m128i_s64(                                     \
+            vsetq_lane_s64((b), vreinterpretq_s64_m128i(a), (imm))); \
     })
 
 // ******************************************

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2773,7 +2773,7 @@ FORCE_INLINE __m128i _mm_aesenc_si128(__m128i EncBlock, __m128i RoundKey)
 inline __m128i _mm_aesenc_si128(__m128i a, __m128i b)
 {
     return vreinterpretq_s32_u8(
-        vaesmcq_u8(vaeseq_u8(vreinterpretq_u8_s32(a), uint8x16_t{})) ^
+        vaesmcq_u8(vaeseq_u8(vreinterpretq_u8_s32(a), vdupq_n_u8(0))) ^
         vreinterpretq_u8_s32(b));
 }
 #endif

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2378,7 +2378,7 @@ FORCE_INLINE __m128 _mm_hadd_ps(__m128 a, __m128 b)
 FORCE_INLINE __m128i _mm_hadd_epi16(__m128i _a, __m128i _b)
 {
     int16x8_t a = vreinterpretq_s16_m128i(_a);
-    int16x8_t b = vreinterpretq_s32_m128i(_b);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
     return vreinterpretq_m128i_s16(
        vcombine_s16(
           vpadd_s16(vget_low_s16(a), vget_high_s16(a)),
@@ -2833,7 +2833,7 @@ FORCE_INLINE __m128i _mm_cvtepu8_epi64(__m128i a)
     uint16x8_t u16x8 = vmovl_u8(vget_low_u8(u8x16));   /* 0x0x 0x0x 0x0x 0B0A */
     uint32x4_t u32x4 = vmovl_u16(vget_low_u16(u16x8)); /* 000x 000x 000B 000A */
     uint64x2_t u64x2 = vmovl_u32(vget_low_u32(u32x4)); /* 0000 000B 0000 000A */
-    return vreinterpretq_m128i_u32(u64x2);
+    return vreinterpretq_m128i_u64(u64x2);
 }
 
 // Converts the four unsigned 8-bit integers in the lower 16 bits to four
@@ -2866,7 +2866,7 @@ FORCE_INLINE __m128i _mm_cvtepi8_epi64(__m128i a)
     int16x8_t s16x8 = vmovl_s8(vget_low_s8(s8x16));   /* 0x0x 0x0x 0x0x 0B0A */
     int32x4_t s32x4 = vmovl_s16(vget_low_s16(s16x8)); /* 000x 000x 000B 000A */
     int64x2_t s64x2 = vmovl_s32(vget_low_s32(s32x4)); /* 0000 000B 0000 000A */
-    return vreinterpretq_m128i_s32(s64x2);
+    return vreinterpretq_m128i_s64(s64x2);
 }
 
 // Converts the four signed 16-bit integers in the lower 64 bits to four signed
@@ -2886,7 +2886,7 @@ FORCE_INLINE __m128i _mm_cvtepi16_epi64(__m128i a)
     int16x8_t s16x8 = vreinterpretq_s16_m128i(a);     /* xxxx xxxx xxxx 0B0A */
     int32x4_t s32x4 = vmovl_s16(vget_low_s16(s16x8)); /* 000x 000x 000B 000A */
     int64x2_t s64x2 = vmovl_s32(vget_low_s32(s32x4)); /* 0000 000B 0000 000A */
-    return vreinterpretq_m128i_s32(s64x2);
+    return vreinterpretq_m128i_s64(s64x2);
 }
 
 // Converts the four unsigned 16-bit integers in the lower 64 bits to four unsigned
@@ -2906,7 +2906,7 @@ FORCE_INLINE __m128i _mm_cvtepu16_epi64(__m128i a)
     uint16x8_t u16x8 = vreinterpretq_u16_m128i(a);     /* xxxx xxxx xxxx 0B0A */
     uint32x4_t u32x4 = vmovl_u16(vget_low_u16(u16x8)); /* 000x 000x 000B 000A */
     uint64x2_t u64x2 = vmovl_u32(vget_low_u32(u32x4)); /* 0000 000B 0000 000A */
-    return vreinterpretq_m128i_u32(u64x2);
+    return vreinterpretq_m128i_u64(u64x2);
 }
 
 // Converts the two unsigned 32-bit integers in the lower 64 bits to two unsigned

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -398,9 +398,16 @@ FORCE_INLINE __m128i _mm_set1_epi32(int _i)
     return vreinterpretq_m128i_s32(vdupq_n_s32(_i));
 }
 
-// Sets the 4 signed 64-bit integer values to i.
+// Sets the 2 signed 64-bit integer values to i.
 // https://msdn.microsoft.com/en-us/library/vstudio/h4xscxat(v=vs.100).aspx
 FORCE_INLINE __m128i _mm_set1_epi64(int64_t _i)
+{
+    return vreinterpretq_m128i_s64(vdupq_n_s64(_i));
+}
+
+// Sets the 2 signed 64-bit integer values to i.
+// https://msdn.microsoft.com/en-us/library/vstudio/h4xscxat(v=vs.100).aspx
+FORCE_INLINE __m128i _mm_set1_epi64x(int64_t _i)
 {
     return vreinterpretq_m128i_s64(vdupq_n_s64(_i));
 }
@@ -2681,6 +2688,16 @@ FORCE_INLINE uint64_t _mm_cvtsi128_si64(__m128i a)
 FORCE_INLINE __m128i _mm_cvtsi32_si128(int a)
 {
     return vreinterpretq_m128i_s32(vsetq_lane_s32(a, vdupq_n_s32(0), 0));
+}
+
+// Moves 64-bit integer a to the least significant 64 bits of an __m128 object,
+// zero extending the upper bits.
+//
+//   r0 := a
+//   r1 := 0x0
+FORCE_INLINE __m128i _mm_cvtsi64_si128(int64_t a)
+{
+    return vreinterpretq_m128i_s64(vsetq_lane_s64(a, vdupq_n_s64(0), 0));
 }
 
 // Applies a type cast to reinterpret four 32-bit floating point values passed

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1405,38 +1405,31 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int count)
         ret;                                                            \
     })
 
-// NEON does not provide a version of this function, here is an article about
-// some ways to repro the results.
-// http://stackoverflow.com/questions/11870910/sse-mm-movemask-epi8-equivalent-method-for-arm-neon
+// NEON does not provide a version of this function.
 // Creates a 16-bit mask from the most significant bits of the 16 signed or
 // unsigned 8-bit integers in a and zero extends the upper bits.
 // https://msdn.microsoft.com/en-us/library/vstudio/s090c8fk(v=vs.100).aspx
 FORCE_INLINE int _mm_movemask_epi8(__m128i _a)
 {
+    // 0x89 FF 1D C0 00 10 99 33
     uint8x16_t input = vreinterpretq_u8_m128i(_a);
-    static const int8_t __attribute__((aligned(16)))
-    xr[8] = {-7, -6, -5, -4, -3, -2, -1, 0};
-    uint8x8_t mask_and = vdup_n_u8(0x80);
-    int8x8_t mask_shift = vld1_s8(xr);
-
-    uint8x8_t lo = vget_low_u8(input);
-    uint8x8_t hi = vget_high_u8(input);
-
-    lo = vand_u8(lo, mask_and);
-    lo = vshl_u8(lo, mask_shift);
-
-    hi = vand_u8(hi, mask_and);
-    hi = vshl_u8(hi, mask_shift);
-
-    lo = vpadd_u8(lo, lo);
-    lo = vpadd_u8(lo, lo);
-    lo = vpadd_u8(lo, lo);
-
-    hi = vpadd_u8(hi, hi);
-    hi = vpadd_u8(hi, hi);
-    hi = vpadd_u8(hi, hi);
-
-    return ((hi[0] << 8) | (lo[0] & 0xFF));
+    // Shift out everything but the sign bits
+    // 0x01 01 00 01 00 00 01 00
+    uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
+    // Merge the even lanes together. The 'xx' bits are garbage.
+    // 0x03xx 02xx 00xx 01xx
+    uint32x4_t paired16 = vreinterpretq_u32_u16(
+                              vsraq_n_u16(high_bits, high_bits, 7));
+    // Repeat.
+    // 0x0Bxxxxxx 04xxxxxx
+    uint64x2_t paired32 = vreinterpretq_u64_u32(
+                              vsraq_n_u32(paired16, paired16, 14));
+    // 0x4Bxxxxxxxxxxxxxx
+    uint8x16_t paired64 = vreinterpretq_u8_u64(
+                              vsraq_n_u64(paired32, paired32, 28));
+    // Extract the low 8 bits from each lane.
+    // 0x4B
+    return vgetq_lane_u8(paired64, 0) | ((int)vgetq_lane_u8(paired64, 8) << 8);
 }
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -122,6 +122,8 @@ enum InstructionTest {
     IT_MM_SET_EPI16,
     IT_MM_SLLI_EPI16,
     IT_MM_SRLI_EPI16,
+    IT_MM_SLL_EPI16,
+    IT_MM_SRL_EPI16,
     IT_MM_CMPEQ_EPI16,
 
     IT_MM_SET1_EPI8,
@@ -138,6 +140,8 @@ enum InstructionTest {
     IT_MM_ADD_EPI8,
     IT_MM_CMPGT_EPI8,
     IT_MM_CMPLT_EPI8,
+    IT_MM_CMPEQ_EPI64,
+    IT_MM_CMPGT_EPI64,
     IT_MM_SUB_EPI8,
     IT_MM_SETR_EPI32,
     IT_MM_MIN_EPU8,


### PR DESCRIPTION
Fixed: 
 - "operand must be constant integer" in Clang
 - Typos in `_mm_shufflelo_function_epi16` were shuffling the wrong lanes
 - C++ style initializer

Improved:
 - Use Clang's `__builtin_shufflevector` if possible - it does most of the work for.us
 - `_mm_movemask_epi8`: use `vsra`  to accumulate the important bits then mask the rest off
 - `_mm_mul_epu32` - Use `vmovn_u64` instead of `vzip`. It is much faster: on v7, it doesn't clobber the source operands, and on A64, it doesn't require 2 steps.
 - `_mm_unpacklo/hi_*` on A64 - use `vzip1`/`vzip2`, the direct equivalents.
 - `_mm_shuffle_epi8` on v7: use 2x `vtbl2` instead of scalarizing it
 - `_mm_slli_*` now uses a variable shift + vdup to work around Clang's pickiness

Added:
```
_mm_sll_epi*
_mm_srl_epi*
_mm_sra_epi*
_mm_sllv_epi*
_mm_srlv_epi*
_mm_srav_epi*
_mm_mul_epi32
_mm_blend_epi16
_mm_blendv_epi8
_mm_cmpeq_epi64
_mm_cmpgt_epi64
_mm_set1_epi64x
_mm_cvtsi64_si128
_mm_extract_epi*
_mm_insert_epi*
_mm_mulhrs_epi16
_mm_maddubs_epi16
_mm_cvtepi*_epi*
_mm_hadd_epi*
_mm_hsub_epi*
_mm_hadds_epi*
_mm_hsubs_epi*
_mm_packus_epi32
_mm_abs_epi8
```
Tests pass. BLAKE2 and XXH3's SSE2 implementations compiled against this also pass their builtin tests in 32-bit and 64-bit mode.