### PR TITLE
implement mm_sll_epi16

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1529,6 +1529,24 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int count)
         ret;                                                            \
     })
 
+// Shifts the 8 signed or unsigned 16-bit integers in a left by count bits while
+// shifting in zeros.
+//
+//   r0 := a0 << count
+//   r1 := a1 << count
+//   ...
+//   r7 := a7 << count
+//
+// https://msdn.microsoft.com/en-us/library/c79w388h(v%3dvs.90).aspx
+FORCE_INLINE __m128i _mm_sll_epi16(__m128i a, __m128i count)
+{
+    uint64_t c = ((SIMDVec *) &count)->m128_u64[0];
+    if (c > 15)
+        return _mm_setzero_si128();
+
+    int16x8_t vc = vdupq_n_s16((int16_t) c);
+    return vreinterpretq_m128i_s16(vshlq_s16(vreinterpretq_s16_m128i(a), vc));
+}
 
 // NEON does not provide a version of this function.
 // Creates a 16-bit mask from the most significant bits of the 16 signed or

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -424,6 +424,9 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
     case IT_MM_SLLI_EPI16:
         ret = "MM_SLLI_EPI16";
         break;
+    case IT_MM_SLL_EPI16:
+        ret = "IT_MM_SLL_EPI16";
+        break;
     case IT_MM_SRLI_EPI16:
         ret = "MM_SRLI_EPI16";
         break;
@@ -1678,6 +1681,25 @@ bool test_mm_slli_epi16(const int16_t *_a)
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
 
+bool test_mm_sll_epi16(const int16_t *_a, const int64_t count)
+{
+    __m128i a = test_mm_load_ps((const int32_t *) _a);
+    __m128i b = _mm_set1_epi64x(count);
+    __m128i c = _mm_sll_epi16(a, b);
+    if (count < 0 || count > 15)
+        return validateInt16(c, 0, 0, 0, 0, 0, 0, 0, 0);
+
+    uint16_t d0 = _a[0] << count;
+    uint16_t d1 = _a[1] << count;
+    uint16_t d2 = _a[2] << count;
+    uint16_t d3 = _a[3] << count;
+    uint16_t d4 = _a[4] << count;
+    uint16_t d5 = _a[5] << count;
+    uint16_t d6 = _a[6] << count;
+    uint16_t d7 = _a[7] << count;
+    return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
+}
+
 bool test_mm_srli_epi16(const int16_t *_a)
 {
     const int count = 3;
@@ -2772,6 +2794,9 @@ public:
             break;
         case IT_MM_SLLI_EPI16:
             ret = test_mm_slli_epi16((const int16_t *) mTestIntPointer1);
+            break;
+        case IT_MM_SLL_EPI16:
+            ret = test_mm_sll_epi16((const int16_t *) mTestIntPointer1, (int64_t) i);
             break;
         case IT_MM_SRLI_EPI16:
             ret = test_mm_srli_epi16((const int16_t *) mTestIntPointer1);

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -122,7 +122,8 @@ enum InstructionTest {
 
     IT_MM_SET1_EPI16,
     IT_MM_SET_EPI16,
-    IT_MM_SLLI_EPI16,
+    IT_MM_SLLI_EPI16,      // Unit test implemented
+    IT_MM_SLL_EPI16,       // Unit test implemented
     IT_MM_SRLI_EPI16,
     IT_MM_CMPEQ_EPI16,
 


### PR DESCRIPTION
The patch passes `make check` on both aarch64 and x86_64.