### PR TITLE
Implement _mm_malloc and _mm_free

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -61,6 +61,7 @@
 #endif
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <arm_neon.h>
 
@@ -3542,6 +3543,26 @@ FORCE_INLINE void _mm_clflush(void const *p)
 {
     (void)p;
     // no corollary for Neon?
+}
+
+// Allocate aligned blocks of memory.
+// https://software.intel.com/en-us/ \
+//         cpp-compiler-developer-guide-and-reference-allocating-and-freeing-aligned-memory-blocks
+FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
+{
+    void *ptr;
+    if (align == 1)
+        return malloc(size);
+    if (align == 2 || (sizeof(void *) == 8 && align == 4))
+        align = sizeof(void *);
+    if (!posix_memalign(&ptr, align, size))
+        return ptr;
+    return NULL;
+}
+
+FORCE_INLINE void _mm_free(void *addr)
+{
+    free(addr);
 }
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -492,6 +492,9 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
     case IT_MM_CLMULEPI64_SI128:
         ret = "IT_MM_CLMULEPI64_SI128";
         break;
+    case IT_MM_MALLOC:
+        ret = "IT_MM_MALLOC";
+        break;
     case IT_LAST: /* should not happend */
         break;
     }
@@ -2381,6 +2384,19 @@ bool test_mm_aesenc_si128(const int32_t *a, const int32_t *b)
     return validate128(resultReference, resultIntrinsic);
 }
 
+bool test_mm_malloc(const size_t *a, const size_t *b)
+{
+    size_t size = *a % (1024 * 16) + 1;
+    size_t align = 2 << (*b % 5);
+
+    void *p = _mm_malloc(size, align);
+    if (!p)
+        return false;
+    bool res = ((uintptr_t) p % align) == 0;
+    _mm_free(p);
+    return res;
+}
+
 // Try 10,000 random floating point values for each test we run
 #define MAX_TEST_VALUE 10000
 
@@ -2853,6 +2869,9 @@ public:
             break;
         case IT_MM_CLMULEPI64_SI128:
             ret = test_mm_clmulepi64_si128((const uint64_t *)mTestIntPointer1, (const uint64_t *)mTestIntPointer2);
+            break;
+        case IT_MM_MALLOC:
+            ret = test_mm_malloc((const size_t *)mTestIntPointer1, (const size_t *) mTestIntPointer2);
             break;
         case IT_LAST: /* should not happend */
             break;

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -147,6 +147,7 @@ enum InstructionTest {
 
     IT_MM_AESENC_SI128,
     IT_MM_CLMULEPI64_SI128,
+    IT_MM_MALLOC,
     IT_LAST
 };
 


### PR DESCRIPTION
_mm_malloc is a wrapper to posix_memalign(), which is specified in
POSIX.1-2001 and POSIX.1-2008.