### PR TITLE
CI: Add coding convention check

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+GCC_REL=9.2-2019.12
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|h)\$" | egrep -v "gcc-arm-${GCC_REL}-x86_64-aarch64-none-linux-gnu|gcc-arm-${GCC_REL}-x86_64-arm-none-linux-gnueabihf")
+
+set -x
+
+exit $(clang-format --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,11 @@ before_install:
 script:
   - make check
   - sh .ci/cross-check.sh
+
+jobs:
+  include:
+    - stage: Coding convention check
+      arch: amd64
+      compiler: gcc
+      before_install: sudo apt-get install -y clang-format
+      script: sh .ci/check-format.sh

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ $(EXEC): $(OBJS)
 check: tests/main
 	$(EXEC_WRAPPER) $^
 
-.PHONY: clean    
+indent:
+	clang-format -i sse2neon.h tests/*.cpp tests/*.h
+
+.PHONY: clean check format
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps)
 


### PR DESCRIPTION
A new script '.ci/check_format.sh' is added
for coding convention check in Travis CI.
The 'make format' target in Makefile is for
following the coding convention.