### PR TITLE
feat: Implement _MM_TRANSPOSE4_PS macro

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -3643,6 +3643,23 @@ FORCE_INLINE int64_t _mm_popcnt_u64(uint64_t a)
 #endif
 }
 
+// Macro: Transpose the 4x4 matrix formed by the 4 rows of single-precision
+// (32-bit) floating-point elements in row0, row1, row2, and row3, and store the
+// transposed matrix in these vectors (row0 now contains column 0, etc.).
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=MM_TRANSPOSE4_PS&expand=5949
+#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
+    do {                                          \
+        __m128 tmp0, tmp1, tmp2, tmp3;            \
+        tmp0 = _mm_unpacklo_ps(row0, row1);       \
+        tmp2 = _mm_unpacklo_ps(row2, row3);       \
+        tmp1 = _mm_unpackhi_ps(row0, row1);       \
+        tmp3 = _mm_unpackhi_ps(row2, row3);       \
+        row0 = _mm_movelh_ps(tmp0, tmp2);         \
+        row1 = _mm_movehl_ps(tmp2, tmp0);         \
+        row2 = _mm_movelh_ps(tmp1, tmp3);         \
+        row3 = _mm_movehl_ps(tmp3, tmp1);         \
+    } while (0)
+
 /* Crypto Extensions */
 
 #if defined(__ARM_FEATURE_CRYPTO)


### PR DESCRIPTION
The test suite is modified to fit the requirement
of 4 input __m128 parameters of _MM_TRANSPOSE4_PS.
The test cases of different input data would be slightly fewer than
before.

Close #10.