### PR TITLE
CI: Prefer latest gcc/clang for validating purpose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,24 @@ compiler:
   - gcc
   - clang
 
+addons:
+  apt:
+    sources:
+      - sourceline: "ppa:ubuntu-toolchain-r/test"
+      - sourceline: "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ bionic-updates main universe"
+    packages:
+      - clang-10
+      - gcc-10
+      - g++-10
+
 before_install:
   - sudo apt-get install -y build-essential
   - sh .ci/cross-tool.sh
+
+install:
+  # /usr/bin/{gcc,clang} points to an older compiler on Ubuntu Linux.
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-10" CC="gcc-10"; fi
+  - if [ "$CXX" = "clang++" ]; then export CXX="clang++-10" CC="clang-10"; fi
 
 script:
   - make check


### PR DESCRIPTION
Developer Ecosystem Engineering from Apple submitted the performance tuning changes for Apple Silicon, and newer toolchains are required to validate.

TODO: add CI matrix to build with the default packages provided by Ubuntu LTS as well.