### PR TITLE
Define macro __has_builtin for GCC prior to 10

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -66,8 +66,15 @@
 /* "__has_builtin" can be used to query support for built-in functions
  * provided by gcc/clang and other compilers that support it.
  */
-#ifndef __has_builtin
-#define __has_builtin(x) 0  // Compatibility with non-{clang,gcc-10} compilers
+#ifndef __has_builtin /* GCC prior to 10 or non-clang compilers */
+/* Compatibility with gcc <= 9 */
+#if __GNUC__ <= 9
+#define __has_builtin(x) HAS##x
+#define HAS__builtin_popcount 1
+#define HAS__builtin_popcountll 1
+#else
+#define __has_builtin(x) 0
+#endif
 #endif
 
 /**


### PR DESCRIPTION
Clang and gcc-10 supports macro __has_builtin, and GCC <= 9 lacks of the
support. This patch attempts to make a limited list for the builtin
functions that we might make use of.