### PR TITLE
CI: Change clang-format version from 10 to 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ jobs:
     - stage: Coding convention check
       arch: amd64
       compiler: gcc
-      before_install: sudo apt-get install -y clang-format
+      before_install: sudo apt-get install -y clang-format-6.0
       script: sh .ci/check-format.sh


### PR DESCRIPTION
The version 10 has a bug with inline assembly.
Please check the following link for more detail:
https://github.com/DLTcollab/sse2neon/pull/71#discussion_r454850578