### PR TITLE
AArch64 implementation of PS FMA and ADDSUB, and some PD load/store/convert

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1271,8 +1271,8 @@ FORCE_INLINE __m128i _mm_shuffle_epi8(__m128i a, __m128i b)
     __asm__ __volatile__(
         "vtbl.8  %e[ret], {%e[tbl], %f[tbl]}, %e[idx]\n"
         "vtbl.8  %f[ret], {%e[tbl], %f[tbl]}, %f[idx]\n"
-        : [ ret ] "=&w"(ret)
-        : [ tbl ] "w"(tbl), [ idx ] "w"(idx_masked));
+        : [ret] "=&w"(ret)
+        : [tbl] "w"(tbl), [idx] "w"(idx_masked));
     return vreinterpretq_m128i_s8(ret);
 #else
     // use this line if testing on aarch64
@@ -4298,8 +4298,8 @@ FORCE_INLINE uint32_t _mm_crc32_u8(uint32_t crc, uint8_t v)
 {
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
     __asm__ __volatile__("crc32cb %w[c], %w[c], %w[v]\n\t"
-                         : [ c ] "+r"(crc)
-                         : [ v ] "r"(v));
+                         : [c] "+r"(crc)
+                         : [v] "r"(v));
 #else
     crc ^= v;
     for (int bit = 0; bit < 8; bit++) {
@@ -4319,8 +4319,8 @@ FORCE_INLINE uint32_t _mm_crc32_u16(uint32_t crc, uint16_t v)
 {
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
     __asm__ __volatile__("crc32ch %w[c], %w[c], %w[v]\n\t"
-                         : [ c ] "+r"(crc)
-                         : [ v ] "r"(v));
+                         : [c] "+r"(crc)
+                         : [v] "r"(v));
 #else
     crc = _mm_crc32_u8(crc, v & 0xff);
     crc = _mm_crc32_u8(crc, (v >> 8) & 0xff);
@@ -4335,8 +4335,8 @@ FORCE_INLINE uint32_t _mm_crc32_u32(uint32_t crc, uint32_t v)
 {
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
     __asm__ __volatile__("crc32cw %w[c], %w[c], %w[v]\n\t"
-                         : [ c ] "+r"(crc)
-                         : [ v ] "r"(v));
+                         : [c] "+r"(crc)
+                         : [v] "r"(v));
 #else
     crc = _mm_crc32_u16(crc, v & 0xffff);
     crc = _mm_crc32_u16(crc, (v >> 16) & 0xffff);
@@ -4351,8 +4351,8 @@ FORCE_INLINE uint64_t _mm_crc32_u64(uint64_t crc, uint64_t v)
 {
 #if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
     __asm__ __volatile__("crc32cx %w[c], %w[c], %x[v]\n\t"
-                         : [ c ] "+r"(crc)
-                         : [ v ] "r"(v));
+                         : [c] "+r"(crc)
+                         : [v] "r"(v));
 #else
     crc = _mm_crc32_u32((uint32_t)(crc), v & 0xffffffff);
     crc = _mm_crc32_u32((uint32_t)(crc), (v >> 32) & 0xffffffff);

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -182,6 +182,9 @@ typedef int64x2_t __m128i; /* 128-bit vector containing integers */
 #define vreinterpret_s32_m64i(x) vreinterpret_s32_s64(x)
 #define vreinterpret_s64_m64i(x) (x)
 
+#define vreinterpretq_m128d_s64(x) vreinterpretq_f64_s64(x)
+#define vreinterpretq_s64_m128d(x) vreinterpretq_s64_f64(x)
+
 // A struct is defined in this header file called 'SIMDVec' which can be used
 // by applications which attempt to access the contents of an _m128 struct
 // directly.  It is important to note that accessing the __m128 struct directly

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -616,7 +616,6 @@ FORCE_INLINE void _mm_store_ss(float *p, __m128 a)
     vst1q_lane_f32(p, vreinterpretq_f32_m128(a), 0);
 }
 
-
 #if defined(__aarch64__)
 // Stores two double-precision to 16-byte aligned memory, floating-point values.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=store_pd&expand=2549,223,3320,3398,5642,5581
@@ -741,7 +740,6 @@ FORCE_INLINE __m128d _mm_load_sd(const double *p)
 #endif
 }
 
-
 // Loads two double-precision from 16-byte aligned memory, floating-point
 // values.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=load_pd&expand=2549,223,3320
@@ -755,7 +753,6 @@ FORCE_INLINE __m128d _mm_load_pd(const double *p)
     return vld1q_f32(data);
 #endif
 }
-
 
 // Loads two double-precision from unaligned memory, floating-point values.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=loadu_pd&expand=2549,223,3320,3398
@@ -2442,13 +2439,10 @@ FORCE_INLINE __m128i _mm_maddubs_epi16(__m128i _a, __m128i _b)
     return vreinterpretq_m128i_s16(vqaddq_s16(prod1, prod2));
 }
 
-
-
 // Computes the fused multiple add product of 32-bit floating point numbers.
 //
 // Return Value
 // Multiplies A and B, and adds C to the temporary result before returning it.
-// The FMA flag is required for this function to be available on X86_64
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_fmadd&expand=2549
 FORCE_INLINE __m128 _mm_fmadd_ps(__m128 a, __m128 b, __m128 c)
 {
@@ -2461,21 +2455,16 @@ FORCE_INLINE __m128 _mm_fmadd_ps(__m128 a, __m128 b, __m128 c)
 #endif
 }
 
-
-
 // Alternatively add and subtract packed single-precision (32-bit)
 // floating-point elements in a to/from packed elements in b, and store the
 // results in dst.
 //
-// The SSE3 flag is required for this function to be available on X86_64
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=addsub_ps&expand=2549,223
 FORCE_INLINE __m128 _mm_addsub_ps(__m128 a, __m128 b)
 {
     __m128 mask = {-1.0f, 1.0f, -1.0f, 1.0f};
     return _mm_fmadd_ps(b, mask, a);
 }
-
-
 
 // Computes the absolute difference of the 16 unsigned 8-bit integers from a
 // and the 16 unsigned 8-bit integers from b.
@@ -3423,7 +3412,6 @@ FORCE_INLINE __m128 _mm_cvtpd_ps(__m128d a)
     return (__m128) _mm_set_epi64(tmp, tmp);
 }
 #endif
-
 
 #if defined(__aarch64__)
 FORCE_INLINE __m128d _mm_cvtps_pd(__m128 a)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -169,6 +169,12 @@ const char *SSE2NEONTest::getInstructionTestString(InstructionTest test)
     case IT_MM_LOAD_SD:
         ret = "MM_LOAD_SD";
         break;
+    case IT_MM_LOAD_PD:
+        ret = "MM_LOAD_PD";
+        break;
+    case IT_MM_LOADU_PD:
+        ret = "MM_LOADU_PD";
+        break;
     case IT_MM_LOAD_SS:
         ret = "MM_LOAD_SS";
         break;
@@ -972,6 +978,18 @@ bool test_mm_load_sd(const double *p)
 {
     __m128d a = _mm_load_sd(p);
     return validateDouble(a, p[0], 0);
+}
+
+bool test_mm_load_pd(const double *p)
+{
+    __m128d a = _mm_load_pd(p);
+    return validateDouble(a, p[0], p[1]);
+}
+
+bool test_mm_loadu_pd(const double *p)
+{
+    __m128d a = _mm_loadu_pd(p);
+    return validateDouble(a, p[0], p[1]);
 }
 
 // r0 := ~a0 & b0
@@ -3240,6 +3258,9 @@ public:
             break;
         case IT_MM_LOAD_SD:
             ret = test_mm_load_sd((const double *) mTestFloatPointer1);
+            break;
+        case IT_MM_LOAD_PD:
+            ret = test_mm_load_pd((const double *) mTestFloatPointer1);
             break;
         case IT_MM_LOAD_SS:
             ret = true;

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -95,6 +95,8 @@ enum InstructionTest {
     IT_MM_CVTSI32_SI128,  // Unimplemented
     IT_MM_CVTTPS_EPI32,
     IT_MM_LOAD_SD,
+    IT_MM_LOAD_PD,
+    IT_MM_LOADU_PD,
     IT_MM_LOAD_SI128,  // Unimplemented
     IT_MM_LOADU_SI128,
     IT_MM_MADD_EPI16,


### PR DESCRIPTION
Hi,

I have implemented, using the AARCH64 Neon intrinsics, the following functions : 
_mm_cvtpd_ps 
_mm_cvtps_pd
 _mm_castpd_si128
 _mm_fmadd_ps,
_mm_addsub_ps
_mm_load_pd
 _mm_loadu_pd
 _mm_store_pd
 _mm_storeu_pd

I have got some more new additions which comes from my simd_utils library, but it seemed too much for one pull request.

Please let me know if you need modifications to this pull request.
