### PR TITLE
Rewrite _MM_TRANSPOSE4_PS with NEON instruction

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -4390,17 +4390,18 @@ FORCE_INLINE int64_t _mm_popcnt_u64(uint64_t a)
 // (32-bit) floating-point elements in row0, row1, row2, and row3, and store the
 // transposed matrix in these vectors (row0 now contains column 0, etc.).
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=MM_TRANSPOSE4_PS
-#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
-    do {                                          \
-        __m128 tmp0, tmp1, tmp2, tmp3;            \
-        tmp0 = _mm_unpacklo_ps(row0, row1);       \
-        tmp2 = _mm_unpacklo_ps(row2, row3);       \
-        tmp1 = _mm_unpackhi_ps(row0, row1);       \
-        tmp3 = _mm_unpackhi_ps(row2, row3);       \
-        row0 = _mm_movelh_ps(tmp0, tmp2);         \
-        row1 = _mm_movehl_ps(tmp2, tmp0);         \
-        row2 = _mm_movelh_ps(tmp1, tmp3);         \
-        row3 = _mm_movehl_ps(tmp3, tmp1);         \
+#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3)         \
+    do {                                                  \
+        float32x4x2_t ROW01 = vtrnq_f32(row0, row1);      \
+        float32x4x2_t ROW23 = vtrnq_f32(row2, row3);      \
+        row0 = vcombine_f32(vget_low_f32(ROW01.val[0]),   \
+                            vget_low_f32(ROW23.val[0]));  \
+        row1 = vcombine_f32(vget_low_f32(ROW01.val[1]),   \
+                            vget_low_f32(ROW23.val[1]));  \
+        row2 = vcombine_f32(vget_high_f32(ROW01.val[0]),  \
+                            vget_high_f32(ROW23.val[0])); \
+        row3 = vcombine_f32(vget_high_f32(ROW01.val[1]),  \
+                            vget_high_f32(ROW23.val[1])); \
     } while (0)
 
 /* Crypto Extensions */


### PR DESCRIPTION
There is a powerful NEON instruction `vtrnq_f32` which can transpose elements in place. We can make use of this instruction.

However, we lack of test cases which validate the combination of several intrinsics. Here is the simplified test program for macro `_MM_TRANSPOSE4_PS`:
```c
void simd8x8Transpose32b(__m128i *pBuffer) {
    __m128 tmp[16];
    for (int n = 0; n < 16; n++)
        tmp[n] = _mm_castsi128_ps(pBuffer[n]);
    _MM_TRANSPOSE4_PS(tmp[0], tmp[2], tmp[4], tmp[6]);
    _MM_TRANSPOSE4_PS(tmp[1], tmp[3], tmp[5], tmp[7]);
    _MM_TRANSPOSE4_PS(tmp[8], tmp[10], tmp[12], tmp[14]);
    _MM_TRANSPOSE4_PS(tmp[9], tmp[11], tmp[13], tmp[15]);
    for (int n = 0; n < 8; n += 2) {
        pBuffer[n] = _mm_castps_si128(tmp[n]);
        pBuffer[n + 1] = _mm_castps_si128(tmp[n + 8]);
        pBuffer[n + 8] = _mm_castps_si128(tmp[n + 1]);
        pBuffer[n + 9] = _mm_castps_si128(tmp[n + 9]);
    }
}
```