### PR TITLE
Drop incorrect _mm_srai_epi32 implementation

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1592,17 +1592,6 @@ FORCE_INLINE __m128i _mm_blendv_epi8(__m128i _a, __m128i _b, __m128i _mask)
 
 /* Shifts */
 
-// Shifts the 4 signed 32-bit integers in a right by count bits while shifting
-// in the sign bit.
-//
-//   r0 := a0 >> count
-//   r1 := a1 >> count
-//   r2 := a2 >> count
-//   r3 := a3 >> count immediate
-FORCE_INLINE __m128i _mm_srai_epi32(__m128i a, int count)
-{
-    return (__m128i) vshlq_s32((int32x4_t) a, vdupq_n_s32(-count));
-}
 
 // Shift packed 16-bit integers in a right by imm while shifting in sign
 // bits, and store the results in dst.


### PR DESCRIPTION
There were two _mm_srai_epi32 implementations: one was the inline function; another was the macro. According to Intel manual, the operation of intrinsic _mm_srai_epi32 is illustrated as following:
    
    __m128i _mm_srai_epi32 (__m128i a, int imm8)
    FOR j := 0 to 3
            i := j*32
            IF imm8[7:0] > 31
                    dst[i+31:i] := (a[i+31] ? 0xFFFFFFFF : 0x0)
            ELSE
                    dst[i+31:i] := SignExtend32(a[i+31:i] >> imm8[7:0])
            FI
    ENDFOR
    
The original inlined function would produce different behavior, and this patch drops it for the sake of correctness.