### PR TITLE
chore: Add cross-compiling tools into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 tests/*.d
 tests/main
+gcc-arm-*


### PR DESCRIPTION
Bash script '.ci/cross-tool.sh' would download cross-compiling tools
for testing. However, these tools are not included in gitignore.