### PR TITLE
feat: Implement A32 counter part of _mm_storeu_pd

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -706,15 +706,14 @@ FORCE_INLINE void _mm_store_pd(double *mem_addr, __m128d a)
 #endif
 }
 
-/* FIXME: Add A32 implementation */
-// Stores two double-precision to unaligned memory, floating-point values.
-// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=storeu_pd
-#if defined(__aarch64__)
-FORCE_INLINE void _mm_storeu_pd(double *p, __m128d a)
+// Store 128-bits (composed of 2 packed double-precision (64-bit) floating-point
+// elements) from a into memory. mem_addr does not need to be aligned on any
+// particular boundary.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_storeu_pd
+FORCE_INLINE void _mm_storeu_pd(double *mem_addr, __m128d a)
 {
-    vst1q_f64(p, (__m128d)(a));
+    _mm_store_pd(mem_addr, a);
 }
-#endif
 
 // Reads the lower 64 bits of b and stores them into the lower 64 bits of a.
 // https://msdn.microsoft.com/en-us/library/hhwf428f%28v=vs.90%29.aspx

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3002,7 +3002,15 @@ result_t test_mm_store_pd(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_storeu_pd(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    double *p = (double *) impl.mTestFloatPointer1;
+    double x = impl.mTestFloats[i + 4];
+    double y = impl.mTestFloats[i + 6];
+
+    __m128d a = _mm_set_pd(x, y);
+    _mm_storeu_pd(p, a);
+    ASSERT_RETURN(p[0] == y);
+    ASSERT_RETURN(p[1] == x);
+    return TEST_SUCCESS;
 }
 
 result_t test_mm_loadl_epi64(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The implementation just calls the __mm_store_pd since the only
difference is the memory alignment restriction.

Related #81.