### PR TITLE
fix: Fix condition for setting zeros _mm_slli_epi16

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1680,7 +1680,7 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int imm)
         __m128i ret;                                             \
         if ((imm) <= 0) {                                        \
             ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
+        } else if ((imm) > 15) {                                 \
             ret = _mm_setzero_si128();                           \
         } else {                                                 \
             ret = vreinterpretq_m128i_s16(                       \


### PR DESCRIPTION
_mm_slli_epi16 would set all the destination bits to zeros when imm8
is greater than 15.

see https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_slli_epi16