### PR TITLE
refactor: Allow non-constant input _mm_slli_epi32

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1693,19 +1693,15 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int imm)
 // shifting in zeros. :
 // https://msdn.microsoft.com/en-us/library/z2k3bbtb%28v=vs.90%29.aspx
 // FORCE_INLINE __m128i _mm_slli_epi32(__m128i a, __constrange(0,255) int imm)
-#define _mm_slli_epi32(a, imm)                                   \
-    __extension__({                                              \
-        __m128i ret;                                             \
-        if ((imm) <= 0) {                                        \
-            ret = a;                                             \
-        } else if ((imm) > 31) {                                 \
-            ret = _mm_setzero_si128();                           \
-        } else {                                                 \
-            ret = vreinterpretq_m128i_s32(                       \
-                vshlq_n_s32(vreinterpretq_s32_m128i(a), (imm))); \
-        }                                                        \
-        ret;                                                     \
-    })
+FORCE_INLINE __m128i _mm_slli_epi32(__m128i a, int imm)
+{
+    if (imm <= 0) /* TODO: add constant range macro: [0, 255] */
+        return a;
+    if (imm > 31) /* TODO: add unlikely macro */
+        return _mm_setzero_si128();
+    return vreinterpretq_m128i_s32(
+        vshlq_s32(vreinterpretq_s32_m128i(a), vdupq_n_s32(imm)));
+}
 
 // Shift packed 64-bit integers in a left by imm8 while shifting in zeros, and
 // store the results in dst.

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3117,7 +3117,27 @@ result_t test_mm_blendv_epi8(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_slli_epi32(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
+    const int32_t *_b = (const int32_t *) impl.mTestIntPointer2;
+#if defined(__clang__)
+    // Clang compiler does not allow the second argument of _mm_slli_epi32() to
+    // be greater than 31.
+    int count = (uint32_t) _b[0] % 32;
+#else
+    int count = (uint32_t) _b[0] % 64;
+    // The value for doing the modulo should be greater
+    // than 32. Using 64 would provide more equal
+    // distribution for both under 32 and above 32 input value.
+#endif
+
+    int32_t d0 = (count > 31) ? 0 : _a[0] << count;
+    int32_t d1 = (count > 31) ? 0 : _a[1] << count;
+    int32_t d2 = (count > 31) ? 0 : _a[2] << count;
+    int32_t d3 = (count > 31) ? 0 : _a[3] << count;
+
+    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i c = _mm_slli_epi32(a, count);
+    return validateInt32(c, d0, d1, d2, d3);
 }
 
 result_t test_mm_srai_epi32(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
_mm_slli_epi32 was not able to take non-constant value for imm.
Test case has been added in this PR, too.