### PR TITLE
fix: Fix wrong behavior of _mm_sign_epi16

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2263,16 +2263,19 @@ FORCE_INLINE __m128i _mm_sign_epi16(__m128i _a, __m128i _b)
     int16x8_t a = vreinterpretq_s16_m128i(_a);
     int16x8_t b = vreinterpretq_s16_m128i(_b);
 
-    int16x8_t zero = vdupq_n_s16(0);
     // signed shift right: faster than vclt
     // (b < 0) ? 0xFFFF : 0
     uint16x8_t ltMask = vreinterpretq_u16_s16(vshrq_n_s16(b, 15));
     // (b == 0) ? 0xFFFF : 0
-    int16x8_t zeroMask = vreinterpretq_s16_u16(vceqq_s16(b, zero));
-    // -a
-    int16x8_t neg = vnegq_s16(a);
-    // bitwise select either a or neg based on ltMask
-    int16x8_t masked = vbslq_s16(ltMask, a, neg);
+#if defined(__aarch64__)
+    int16x8_t zeroMask = vreinterpretq_s16_u16(vceqzq_s16(b));
+#else
+    int16x8_t zeroMask = vreinterpretq_s16_u16(vceqq_s16(b, vdupq_n_s16(0)));
+#endif
+
+    // bitwise select either a or negative 'a' (vnegq_s16(a) equals to negative
+    // 'a') based on ltMask
+    int16x8_t masked = vbslq_s16(ltMask, vnegq_s16(a), a);
     // res = masked & (~zeroMask)
     int16x8_t res = vbicq_s16(masked, zeroMask);
     return vreinterpretq_m128i_s16(res);

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3229,7 +3229,25 @@ result_t test_mm_sign_epi8(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_sign_epi16(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
+    const int16_t *_b = (const int16_t *) impl.mTestIntPointer2;
+
+    int16_t d[8];
+    for (int i = 0; i < 8; i++) {
+        if (_b[i] < 0) {
+            d[i] = -_a[i];
+        } else if (_b[i] == 0) {
+            d[i] = 0;
+        } else {
+            d[i] = _a[i];
+        }
+    }
+
+    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i c = _mm_sign_epi16(a, b);
+
+    return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 }
 
 result_t test_mm_sign_epi32(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The behavior of _mm_sign_epi16 is opposite. The wrong behavior has been
fixed in this PR. A64 operation and test case have been appended in
this PR, too.