### PR TITLE
refactor: Use UZP for A64 in _mm_hsubs_epi16

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -3192,8 +3192,15 @@ FORCE_INLINE __m128i _mm_hadds_epi16(__m128i _a, __m128i _b)
 
 // Computes saturated pairwise difference of each argument as a 16-bit signed
 // integer values a and b.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_hsubs_epi16
 FORCE_INLINE __m128i _mm_hsubs_epi16(__m128i _a, __m128i _b)
 {
+#if defined(__aarch64__)
+    int16x8_t a = vreinterpretq_s16_m128i(_a);
+    int16x8_t b = vreinterpretq_s16_m128i(_b);
+    return vreinterpretq_s64_s16(
+        vqsubq_s16(vuzp1q_s16(a, b), vuzp2q_s16(a, b)));
+#else
     int32x4_t a = vreinterpretq_s32_m128i(_a);
     int32x4_t b = vreinterpretq_s32_m128i(_b);
     // Interleave using vshrn/vmovn
@@ -3203,6 +3210,7 @@ FORCE_INLINE __m128i _mm_hsubs_epi16(__m128i _a, __m128i _b)
     int16x8_t ab1357 = vcombine_s16(vshrn_n_s32(a, 16), vshrn_n_s32(b, 16));
     // Saturated subtract
     return vreinterpretq_m128i_s16(vqsubq_s16(ab0246, ab1357));
+#endif
 }
 
 // Computes pairwise add of each argument as a 32-bit signed or unsigned integer

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3399,7 +3399,40 @@ result_t test_mm_hadds_epi16(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_hsubs_epi16(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const int16_t s16_min = 0x8000;
+    const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
+    const int16_t *_b = (const int16_t *) impl.mTestIntPointer1;
+
+    int16_t d0 = (((int32_t) _a[0] - (int32_t) _a[1]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _a[0] - (int32_t) _a[1]);
+    int16_t d1 = (((int32_t) _a[2] - (int32_t) _a[3]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _a[2] - (int32_t) _a[3]);
+    int16_t d2 = (((int32_t) _a[4] - (int32_t) _a[5]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _a[4] - (int32_t) _a[5]);
+    int16_t d3 = (((int32_t) _a[6] - (int32_t) _a[7]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _a[6] - (int32_t) _a[7]);
+    int16_t d4 = (((int32_t) _b[0] - (int32_t) _b[1]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _b[0] - (int32_t) _b[1]);
+    int16_t d5 = (((int32_t) _b[2] - (int32_t) _b[3]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _b[2] - (int32_t) _b[3]);
+    int16_t d6 = (((int32_t) _b[4] - (int32_t) _b[5]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _b[4] - (int32_t) _b[5]);
+    int16_t d7 = (((int32_t) _b[6] - (int32_t) _b[7]) <= (int32_t) s16_min)
+                     ? s16_min
+                     : ((int32_t) _b[6] - (int32_t) _b[7]);
+
+    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i c = _mm_hsubs_epi16(a, b);
+
+    return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
 
 result_t test_mm_hadd_epi32(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
In A64, `_mm_hsubs_epi16` applies `vuzp1q_s16` and `vuzp2q_s16`.