### PR TITLE
Improve _mm_{max,min}_ps

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2806,110 +2806,15 @@ FORCE_INLINE __m128 _mm_rsqrt_ss(__m128 in)
     return vsetq_lane_f32(vgetq_lane_f32(_mm_rsqrt_ps(in), 0), in, 0);
 }
 
-#if SSE2NEON_PRECISE_MINMAX
-// Check if input is sNaN
-FORCE_INLINE uint32x4_t _sse2neon_is_snan(float32x4_t a)
-{
-    // all exp bits are 1 and MSB bit of mantissa is 1
-    const uint32x4_t vexp_mask = {0x7f800000, 0x7f800000, 0x7f800000,
-                                  0x7f800000};
-    const uint32x4_t vqnan_bit_mask = {0x00400000, 0x00400000, 0x00400000,
-                                       0x00400000};
-    const uint32x4_t vsnan_bit_mask = {0x003fffff, 0x003fffff, 0x003fffff,
-                                       0x003fffff};
-    const uint32x4_t vzero = vdupq_n_u32(0);
-
-    uint32x4_t v_exp_all_ones =
-        vceqq_u32(vandq_u32(vreinterpretq_u32_f32(a), vexp_mask), vexp_mask);
-
-    // Check if qnan mantissa bits is off
-    uint32x4_t v_qnan_bit_off =
-        vceqq_u32(vandq_u32(vreinterpretq_u32_f32(a), vqnan_bit_mask), vzero);
-    uint32x4_t v_snan_bit_any =
-        vcgtq_u32(vandq_u32(vreinterpretq_u32_f32(a), vsnan_bit_mask), vzero);
-
-    uint32x4_t v_is_snan =
-        vandq_u32(vandq_u32(v_exp_all_ones, v_qnan_bit_off), v_snan_bit_any);
-
-    return v_is_snan;
-}
-
-// Check if input is NaN (sNaN or qNan)
-FORCE_INLINE uint32x4_t _sse2neon_is_nan(float32x4_t a)
-{
-    const uint32x4_t vexp_mask = {0x7f800000, 0x7f800000, 0x7f800000,
-                                  0x7f800000};
-    const uint32x4_t vmantissa_mask = {0x007fffff, 0x007fffff, 0x007fffff,
-                                       0x007fffff};
-    const uint32x4_t vzero = vdupq_n_u32(0);
-
-    // Check if all exp bits are 1.
-    uint32x4_t v_exp_all_ones =
-        vceqq_u32(vandq_u32(vreinterpretq_u32_f32(a), vexp_mask), vexp_mask);
-
-    // Check if any mantissa bits are on(qNaN or sNaN)
-    uint32x4_t v_mantissa_any =
-        vcgtq_u32(vandq_u32(vreinterpretq_u32_f32(a), vmantissa_mask), vzero);
-
-    return vandq_u32(v_exp_all_ones, v_mantissa_any);
-}
-
-// Accurate simulation of _mm_min_ps using NEON
-FORCE_INLINE float32x4_t _sse2neon_vmin(float32x4_t a, float32x4_t b)
-{
-    // when both input are (+/-)0.0, return the second
-    // when the first input is NaN (sNaN or qNaN), return the second.
-    // when the second input is sNaN, return sNaN (return the second).
-    // otherwise return min(a, b)
-    const float32x4_t vzero = vdupq_n_f32(0.0f);
-    const uint32x4_t v_src1_is_snan = _sse2neon_is_snan(b);
-
-    // fortunately, ceqq_f32 ignores the sign.
-    const uint32x4_t v_both_are_zeros =
-        vandq_u32(vceqq_f32(a, vzero), vceqq_f32(b, vzero));
-
-    const uint32x4_t v_src0_is_nan = _sse2neon_is_nan(a);
-
-    const float32x4_t v_min = vminq_f32(a, b);
-
-    float32x4_t v_special_case = vbslq_f32(v_both_are_zeros, b, v_min);
-    v_special_case = vbslq_f32(v_src0_is_nan, b, v_special_case);
-    v_special_case = vbslq_f32(v_src1_is_snan, b, v_special_case);
-    return v_special_case;
-}
-
-// Accurate simulation of _mm_max_ps using NEON
-FORCE_INLINE float32x4_t _sse2neon_vmax(float32x4_t a, float32x4_t b)
-{
-    // when both input are (+/-)0.0, return the second
-    // when the first input is NaN(sNaN or qNaN), return the second.
-    // when the second input is sNaN, return sNaN(return the second).
-    // otherwise return max(a, b)
-    const float32x4_t vzero = vdupq_n_f32(0.0f);
-    const uint32x4_t v_src1_is_snan = _sse2neon_is_snan(b);
-
-    // fortunately, ceqq_f32 ignores the sign.
-    const uint32x4_t v_both_are_zeros =
-        vandq_u32(vceqq_f32(a, vzero), vceqq_f32(b, vzero));
-
-    const uint32x4_t v_src0_is_nan = _sse2neon_is_nan(a);
-
-    const float32x4_t v_max = vmaxq_f32(a, b);
-
-    float32x4_t v_special_case = vbslq_f32(v_both_are_zeros, b, v_max);
-    v_special_case = vbslq_f32(v_src0_is_nan, b, v_special_case);
-    v_special_case = vbslq_f32(v_src1_is_snan, b, v_special_case);
-    return v_special_case;
-}
-#endif
-
 // Computes the maximums of the four single-precision, floating-point values of
 // a and b.
 // https://msdn.microsoft.com/en-us/library/vstudio/ff5d607a(v=vs.100).aspx
 FORCE_INLINE __m128 _mm_max_ps(__m128 a, __m128 b)
 {
 #if SSE2NEON_PRECISE_MINMAX
-    return _sse2neon_vmax(a, b);
+    float32x4_t _a = vreinterpretq_f32_m128(a);
+    float32x4_t _b = vreinterpretq_f32_m128(b);
+    return vbslq_f32(vcltq_f32(_b, _a), _a, _b);
 #else
     return vreinterpretq_m128_f32(
         vmaxq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
@@ -2922,7 +2827,9 @@ FORCE_INLINE __m128 _mm_max_ps(__m128 a, __m128 b)
 FORCE_INLINE __m128 _mm_min_ps(__m128 a, __m128 b)
 {
 #if SSE2NEON_PRECISE_MINMAX
-    return _sse2neon_vmin(a, b);
+    float32x4_t _a = vreinterpretq_f32_m128(a);
+    float32x4_t _b = vreinterpretq_f32_m128(b);
+    return vbslq_f32(vcltq_f32(_a, _b), _a, _b);
 #else
     return vreinterpretq_m128_f32(
         vminq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
@@ -2934,12 +2841,7 @@ FORCE_INLINE __m128 _mm_min_ps(__m128 a, __m128 b)
 // https://msdn.microsoft.com/en-us/library/s6db5esz(v=vs.100).aspx
 FORCE_INLINE __m128 _mm_max_ss(__m128 a, __m128 b)
 {
-#if SSE2NEON_PRECISE_MINMAX
-    float32_t value = vgetq_lane_f32(_sse2neon_vmax(a, b), 0);
-#else
-    float32_t value = vgetq_lane_f32(
-        vmaxq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)), 0);
-#endif
+    float32_t value = vgetq_lane_f32(_mm_max_ps(a, b), 0);
     return vreinterpretq_m128_f32(
         vsetq_lane_f32(value, vreinterpretq_f32_m128(a), 0));
 }
@@ -2949,12 +2851,7 @@ FORCE_INLINE __m128 _mm_max_ss(__m128 a, __m128 b)
 // https://msdn.microsoft.com/en-us/library/0a9y7xaa(v=vs.100).aspx
 FORCE_INLINE __m128 _mm_min_ss(__m128 a, __m128 b)
 {
-#if SSE2NEON_PRECISE_MINMAX
-    float32_t value = vgetq_lane_f32(_sse2neon_vmin(a, b), 0);
-#else
-    float32_t value = vgetq_lane_f32(
-        vminq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)), 0);
-#endif
+    float32_t value = vgetq_lane_f32(_mm_min_ps(a, b), 0);
     return vreinterpretq_m128_f32(
         vsetq_lane_f32(value, vreinterpretq_f32_m128(a), 0));
 }


### PR DESCRIPTION
The precise `_mm_min_ps` can be implemented as

```c
FORCE_INLINE __m128 _mm_min_ps(__m128 a, __m128 b)
{
    return vbslq_f32(vcltq_f32(a, b), a, b);
}
```

Derived from https://github.com/lighttransport/embree-aarch64/pull/33