### PR TITLE
test: Add declaration of test_mm_setzero_pd

### DIFF
--- a/tests/impl.h
+++ b/tests/impl.h
@@ -212,6 +212,7 @@
     TYPE(mm_setr_epi32)               \
     TYPE(mm_setr_epi64)               \
     TYPE(mm_setr_epi8)                \
+    TYPE(mm_setzero_pd)               \
     TYPE(mm_setzero_si128)            \
     TYPE(mm_sll_epi16)                \
     TYPE(mm_sll_epi32)                \


### PR DESCRIPTION
test `test_mm_setzero_pd` was not declared in `impl.h`