### PR TITLE
CI: Add the yaml file for Github Actions

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -5,4 +5,4 @@ SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|h)\$" | egrep -v
 
 set -x
 
-exit $(clang-format --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $(clang-format-6.0 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -1,0 +1,56 @@
+name: Github Actions
+
+on: [push, pull_request]
+
+jobs:
+  test_x86:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cxx_compiler: [g++-10, clang++-10]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: test
+        env:
+          CXX: ${{ matrix.cxx_compiler }}
+        run: |
+          sh .ci/cross-tool.sh
+          make check
+          sh .ci/cross-check.sh
+
+  test_arm:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        arch: [armv7, aarch64]
+        cxx_compiler: [g++-10, clang++-10]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: test
+        # The Github Action for non-x86 CPU
+        # https://github.com/uraimo/run-on-arch-action
+        uses: uraimo/run-on-arch-action@v2.0.5
+        with:
+          arch: ${{ matrix.arch }}
+          env: |
+            CXX: ${{ matrix.cxx_compiler }}
+          install: |
+            apt-get update -y
+            # Install add-apt-repository
+            apt-get install -y software-properties-common
+            # For installing g++-10
+            add-apt-repository ppa:ubuntu-toolchain-r/test -y
+            apt-get update -y
+            apt-get install -y g++-10 clang++-10 make
+          run: make check
+
+  coding_convention:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: coding convention
+        run: sh .ci/check-format.sh
+        shell: bash

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(processor),aarch64)
     ARCH_CFLAGS = -march=armv8-a+fp+simd+crc
 else ifeq ($(processor),$(filter $(processor),i386 x86_64))
     ARCH_CFLAGS = -maes -mpclmul -mssse3 -msse4.2
-else ifeq ($(processor),arm)
+else ifeq ($(processor),$(filter $(processor),arm armv7l))
     ARCH_CFLAGS = -mfpu=neon
 else
     $(error Unsupported architecture)


### PR DESCRIPTION
check-format.sh:
The clang-format should use version 6 instead of 10.
Discussion: #71 (comment)
Makefile:
The returned processor type of Github Actions arm 32-bit platform is armv7l,
hence it should be included in Makefile detection.
github_actions.yml:
The non-x86 CPU architecture is offered by https://github.com/uraimo/run-on-arch-action.
The related YAML should be written by following the document rule.

Close #253.