### PR TITLE
fix: Complete mm_blendv_ps with signed shift right 

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5118,11 +5118,14 @@ FORCE_INLINE __m128 _mm_castpd_ps(__m128d a)
 // Blend packed single-precision (32-bit) floating-point elements from a and b
 // using mask, and store the results in dst.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blendv_ps
-FORCE_INLINE __m128 _mm_blendv_ps(__m128 a, __m128 b, __m128 mask)
+FORCE_INLINE __m128 _mm_blendv_ps(__m128 _a, __m128 _b, __m128 _mask)
 {
-    return vreinterpretq_m128_f32(vbslq_f32(vreinterpretq_u32_m128(mask),
-                                            vreinterpretq_f32_m128(b),
-                                            vreinterpretq_f32_m128(a)));
+    // Use a signed shift right to create a mask with the sign bit
+    uint32x4_t mask =
+        vreinterpretq_u32_s32(vshrq_n_s32(vreinterpretq_s32_m128(_mask), 31));
+    float32x4_t a = vreinterpretq_f32_m128(_a);
+    float32x4_t b = vreinterpretq_f32_m128(_b);
+    return vreinterpretq_m128_f32(vbslq_f32(mask, b, a));
 }
 
 // Blend packed double-precision (64-bit) floating-point elements from a and b

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -5321,7 +5321,29 @@ result_t test_mm_blendv_epi8(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_blendv_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const float *_a = impl.mTestFloatPointer1;
+    const float *_b = impl.mTestFloatPointer2;
+    const float _mask[] = {impl.mTestFloats[i], impl.mTestFloats[i+1],
+                           impl.mTestFloats[i+2], impl.mTestFloats[i+3]};
+
+    float _c[4];
+    for (int i = 0; i < 4; i++) {
+        // signed shift right would return a result which is either all 1's from
+        // negative numbers or all 0's from positive numbers
+        if ((*(const int32_t *) (_mask + i)) >> 31) {
+            _c[i] = _b[i];
+        } else {
+            _c[i] = _a[i];
+        }
+    }
+
+    __m128 a = do_mm_load_ps(_a);
+    __m128 b = do_mm_load_ps(_b);
+    __m128 mask = do_mm_load_ps(_mask);
+
+    __m128 c = _mm_blendv_ps(a, b, mask);
+
+    return validateFloat(c, _c[0], _c[1], _c[2], _c[3]);
 }
 
 result_t test_mm_blendv_pd(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
Mapping `_mm_blendv_ps` intrinsics directly with `vbslq_f32` is not an
accurate implementaion. We should take signed shift right then call
`vbslq_f32`.