### PR TITLE
feat: Declare unimplemented intrinsics

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -6149,6 +6149,7 @@ result_t test_mm_popcnt_u64(const SSE2NEONTestImpl &impl, uint32_t i)
     return TEST_SUCCESS;
 }
 
+/* Unimplemented */
 result_t test_mm_shuffle_epi32(const SSE2NEONTestImpl &impl, uint32_t i)
 {
     return TEST_UNIMPL;
@@ -6193,6 +6194,851 @@ result_t test_mm_shufflelo_epi16(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_shufflelo_epi16_function(const SSE2NEONTestImpl &impl,
                                           uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtps_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtps_pi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtps_pi8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_extract_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_getcsr(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_maskmove_si64(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_maskmovq(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_movemask_pi8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pavgb(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pavgw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pextrw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pinsrw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pmaxsw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pmaxub(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pminsw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pminub(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pmovmskb(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pmulhuw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_psadbw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_m_pshufw(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_setcsr(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_shuffle_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_store_ps1(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_store1_ps(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storer_ps(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storeu_si16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storeu_si64(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_stream_pi(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomieq_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomige_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomigt_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomile_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomilt_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomineq_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_add_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_bslli_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_bsrli_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_castsi128_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpeq_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpeq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpge_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpge_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpgt_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpgt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmple_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmple_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmplt_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmplt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpneq_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpneq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnge_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnge_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpngt_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpngt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnle_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnle_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnlt_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpnlt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpord_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpord_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpunord_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpunord_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comieq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comige_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comigt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comile_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comilt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_comineq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtepi32_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtpd_pi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtpi32_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsd_si32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsd_si64(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsd_si64x(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsd_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsi128_si64x(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsi32_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsi64_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsi64x_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtsi64x_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvtss_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvttpd_epi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cvttsd_si32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_div_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_div_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_lfence(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_load_pd1(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_maskmoveu_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_max_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_max_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_mfence(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_min_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_min_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_movemask_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_mul_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_pause(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_set_pd1(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_set_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_setr_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_shuffle_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_sqrt_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_sqrt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_store_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storeh_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storel_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storer_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_storeu_si32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_stream_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_stream_si32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_stream_si64(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_sub_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_sub_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomieq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomige_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomigt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomile_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomilt_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ucomineq_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_undefined_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_undefined_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_unpackhi_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_unpacklo_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_addsub_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hadd_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hsub_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_lddqu_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_loaddup_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_movedup_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_alignr_pi8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hadds_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hsub_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hsub_pi32(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_hsubs_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_maddubs_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_mulhrs_pi16(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_shuffle_pi8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_blend_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ceil_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ceil_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_ceil_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_floor_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_floor_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_floor_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_insert_ps(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_mpsadbw_epu8(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_round_pd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_round_sd(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_round_ss(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_testnzc_si128(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestra(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestrc(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestri(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestrm(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestro(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestrs(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpestrz(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistra(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistrc(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistri(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistrm(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistro(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistrs(const SSE2NEONTestImpl &impl, uint32_t i)
+{
+    return TEST_UNIMPL;
+}
+
+result_t test_mm_cmpistrz(const SSE2NEONTestImpl &impl, uint32_t i)
 {
     return TEST_UNIMPL;
 }

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -53,6 +53,9 @@
     TYPE(mm_cvtpi32_ps)               \
     TYPE(mm_cvtpi32x2_ps)             \
     TYPE(mm_cvtpi8_ps)                \
+    TYPE(mm_cvtps_pi16)               \
+    TYPE(mm_cvtps_pi32)               \
+    TYPE(mm_cvtps_pi8)                \
     TYPE(mm_cvtpu16_ps)               \
     TYPE(mm_cvtpu8_ps)                \
     TYPE(mm_cvtsi32_ss)               \
@@ -67,7 +70,9 @@
     TYPE(mm_cvttss_si64)              \
     TYPE(mm_div_ps)                   \
     TYPE(mm_div_ss)                   \
+    TYPE(mm_extract_pi16)             \
     TYPE(mm_free)                     \
+    TYPE(mm_getcsr)                   \
     TYPE(mm_insert_pi16)              \
     TYPE(mm_load_ps)                  \
     TYPE(mm_load_ps1)                 \
@@ -80,6 +85,8 @@
     TYPE(mm_loadu_si16)               \
     TYPE(mm_loadu_si64)               \
     TYPE(mm_malloc)                   \
+    TYPE(mm_maskmove_si64)            \
+    TYPE(m_maskmovq)                  \
     TYPE(mm_max_pi16)                 \
     TYPE(mm_max_ps)                   \
     TYPE(mm_max_pu8)                  \
@@ -91,13 +98,25 @@
     TYPE(mm_move_ss)                  \
     TYPE(mm_movehl_ps)                \
     TYPE(mm_movelh_ps)                \
+    TYPE(mm_movemask_pi8)             \
     TYPE(mm_movemask_ps)              \
     TYPE(mm_mul_ps)                   \
-    TYPE(mm_mul_pd)                   \
     TYPE(mm_mul_ss)                   \
     TYPE(mm_mulhi_pu16)               \
     TYPE(mm_or_ps)                    \
+    TYPE(m_pavgb)                     \
+    TYPE(m_pavgw)                     \
+    TYPE(m_pextrw)                    \
+    TYPE(m_pinsrw)                    \
+    TYPE(m_pmaxsw)                    \
+    TYPE(m_pmaxub)                    \
+    TYPE(m_pminsw)                    \
+    TYPE(m_pminub)                    \
+    TYPE(m_pmovmskb)                  \
+    TYPE(m_pmulhuw)                   \
     TYPE(mm_prefetch)                 \
+    TYPE(m_psadbw)                    \
+    TYPE(m_pshufw)                    \
     TYPE(mm_rcp_ps)                   \
     TYPE(mm_rcp_ss)                   \
     TYPE(mm_rsqrt_ps)                 \
@@ -107,20 +126,34 @@
     TYPE(mm_set_ps1)                  \
     TYPE(mm_set_ss)                   \
     TYPE(mm_set1_ps)                  \
+    TYPE(mm_setcsr)                   \
     TYPE(mm_setr_ps)                  \
     TYPE(mm_setzero_ps)               \
     TYPE(mm_sfence)                   \
+    TYPE(mm_shuffle_pi16)             \
     TYPE(mm_shuffle_ps)               \
     TYPE(mm_sqrt_ps)                  \
     TYPE(mm_sqrt_ss)                  \
     TYPE(mm_store_ps)                 \
+    TYPE(mm_store_ps1)                \
     TYPE(mm_store_ss)                 \
+    TYPE(mm_store1_ps)                \
     TYPE(mm_storeh_pi)                \
     TYPE(mm_storel_pi)                \
+    TYPE(mm_storer_ps)                \
     TYPE(mm_storeu_ps)                \
+    TYPE(mm_storeu_si16)              \
+    TYPE(mm_storeu_si64)              \
+    TYPE(mm_stream_pi)                \
     TYPE(mm_stream_ps)                \
     TYPE(mm_sub_ps)                   \
     TYPE(mm_sub_ss)                   \
+    TYPE(mm_ucomieq_ss)               \
+    TYPE(mm_ucomige_ss)               \
+    TYPE(mm_ucomigt_ss)               \
+    TYPE(mm_ucomile_ss)               \
+    TYPE(mm_ucomilt_ss)               \
+    TYPE(mm_ucomineq_ss)              \
     TYPE(mm_undefined_ps)             \
     TYPE(mm_unpackhi_ps)              \
     TYPE(mm_unpacklo_ps)              \
@@ -131,6 +164,7 @@
     TYPE(mm_add_epi64)                \
     TYPE(mm_add_epi8)                 \
     TYPE(mm_add_pd)                   \
+    TYPE(mm_add_sd)                   \
     TYPE(mm_add_si64)                 \
     TYPE(mm_adds_epi16)               \
     TYPE(mm_adds_epi8)                \
@@ -142,36 +176,90 @@
     TYPE(mm_andnot_si128)             \
     TYPE(mm_avg_epu16)                \
     TYPE(mm_avg_epu8)                 \
+    TYPE(mm_bslli_si128)              \
+    TYPE(mm_bsrli_si128)              \
     TYPE(mm_castpd_ps)                \
     TYPE(mm_castpd_si128)             \
     TYPE(mm_castps_pd)                \
     TYPE(mm_castps_si128)             \
+    TYPE(mm_castsi128_pd)             \
     TYPE(mm_castsi128_ps)             \
     TYPE(mm_clflush)                  \
     TYPE(mm_cmpeq_epi16)              \
     TYPE(mm_cmpeq_epi32)              \
     TYPE(mm_cmpeq_epi8)               \
+    TYPE(mm_cmpeq_pd)                 \
+    TYPE(mm_cmpeq_sd)                 \
+    TYPE(mm_cmpge_pd)                 \
+    TYPE(mm_cmpge_sd)                 \
     TYPE(mm_cmpgt_epi16)              \
     TYPE(mm_cmpgt_epi32)              \
     TYPE(mm_cmpgt_epi8)               \
+    TYPE(mm_cmpgt_pd)                 \
+    TYPE(mm_cmpgt_sd)                 \
+    TYPE(mm_cmple_pd)                 \
+    TYPE(mm_cmple_sd)                 \
     TYPE(mm_cmplt_epi16)              \
     TYPE(mm_cmplt_epi32)              \
     TYPE(mm_cmplt_epi8)               \
+    TYPE(mm_cmplt_pd)                 \
+    TYPE(mm_cmplt_sd)                 \
+    TYPE(mm_cmpneq_pd)                \
+    TYPE(mm_cmpneq_sd)                \
+    TYPE(mm_cmpnge_pd)                \
+    TYPE(mm_cmpnge_sd)                \
+    TYPE(mm_cmpngt_pd)                \
+    TYPE(mm_cmpngt_sd)                \
+    TYPE(mm_cmpnle_pd)                \
+    TYPE(mm_cmpnle_sd)                \
+    TYPE(mm_cmpnlt_pd)                \
+    TYPE(mm_cmpnlt_sd)                \
+    TYPE(mm_cmpord_pd)                \
+    TYPE(mm_cmpord_sd)                \
+    TYPE(mm_cmpunord_pd)              \
+    TYPE(mm_cmpunord_sd)              \
+    TYPE(mm_comieq_sd)                \
+    TYPE(mm_comige_sd)                \
+    TYPE(mm_comigt_sd)                \
+    TYPE(mm_comile_sd)                \
+    TYPE(mm_comilt_sd)                \
+    TYPE(mm_comineq_sd)               \
+    TYPE(mm_cvtepi32_pd)              \
     TYPE(mm_cvtepi32_ps)              \
+    TYPE(mm_cvtpd_epi32)              \
+    TYPE(mm_cvtpd_pi32)               \
     TYPE(mm_cvtpd_ps)                 \
+    TYPE(mm_cvtpi32_pd)               \
     TYPE(mm_cvtps_epi32)              \
     TYPE(mm_cvtps_pd)                 \
     TYPE(mm_cvtsd_f64)                \
+    TYPE(mm_cvtsd_si32)               \
+    TYPE(mm_cvtsd_si64)               \
+    TYPE(mm_cvtsd_si64x)              \
+    TYPE(mm_cvtsd_ss)                 \
     TYPE(mm_cvtsi128_si32)            \
     TYPE(mm_cvtsi128_si64)            \
+    TYPE(mm_cvtsi128_si64x)           \
+    TYPE(mm_cvtsi32_sd)               \
     TYPE(mm_cvtsi32_si128)            \
+    TYPE(mm_cvtsi64_sd)               \
     TYPE(mm_cvtsi64_si128)            \
+    TYPE(mm_cvtsi64x_sd)              \
+    TYPE(mm_cvtsi64x_si128)           \
+    TYPE(mm_cvtss_sd)                 \
+    TYPE(mm_cvttpd_epi32)             \
+    TYPE(mm_cvttpd_pi32)              \
     TYPE(mm_cvttps_epi32)             \
+    TYPE(mm_cvttsd_si32)              \
     TYPE(mm_cvttsd_si64)              \
     TYPE(mm_cvttsd_si64x)             \
+    TYPE(mm_div_pd)                   \
+    TYPE(mm_div_sd)                   \
     TYPE(mm_extract_epi16)            \
     TYPE(mm_insert_epi16)             \
+    TYPE(mm_lfence)                   \
     TYPE(mm_load_pd)                  \
+    TYPE(mm_load_pd1)                 \
     TYPE(mm_load_sd)                  \
     TYPE(mm_load_si128)               \
     TYPE(mm_load1_pd)                 \
@@ -183,24 +271,35 @@
     TYPE(mm_loadu_si128)              \
     TYPE(mm_loadu_si32)               \
     TYPE(mm_madd_epi16)               \
+    TYPE(mm_maskmoveu_si128)          \
     TYPE(mm_max_epi16)                \
     TYPE(mm_max_epu8)                 \
+    TYPE(mm_max_pd)                   \
+    TYPE(mm_max_sd)                   \
+    TYPE(mm_mfence)                   \
     TYPE(mm_min_epi16)                \
     TYPE(mm_min_epu8)                 \
+    TYPE(mm_min_pd)                   \
+    TYPE(mm_min_sd)                   \
     TYPE(mm_move_epi64)               \
     TYPE(mm_move_sd)                  \
     TYPE(mm_movemask_epi8)            \
+    TYPE(mm_movemask_pd)              \
     TYPE(mm_movepi64_pi64)            \
     TYPE(mm_movpi64_epi64)            \
     TYPE(mm_mul_epu32)                \
+    TYPE(mm_mul_pd)                   \
+    TYPE(mm_mul_sd)                   \
     TYPE(mm_mul_su32)                 \
     TYPE(mm_mulhi_epi16)              \
+    TYPE(mm_mulhi_epu16)              \
     TYPE(mm_mullo_epi16)              \
     TYPE(mm_or_pd)                    \
     TYPE(mm_or_si128)                 \
     TYPE(mm_packs_epi16)              \
     TYPE(mm_packs_epi32)              \
     TYPE(mm_packus_epi16)             \
+    TYPE(mm_pause)                    \
     TYPE(mm_sad_epu8)                 \
     TYPE(mm_set_epi16)                \
     TYPE(mm_set_epi32)                \
@@ -208,6 +307,8 @@
     TYPE(mm_set_epi64x)               \
     TYPE(mm_set_epi8)                 \
     TYPE(mm_set_pd)                   \
+    TYPE(mm_set_pd1)                  \
+    TYPE(mm_set_sd)                   \
     TYPE(mm_set1_epi16)               \
     TYPE(mm_set1_epi32)               \
     TYPE(mm_set1_epi64)               \
@@ -218,8 +319,13 @@
     TYPE(mm_setr_epi32)               \
     TYPE(mm_setr_epi64)               \
     TYPE(mm_setr_epi8)                \
+    TYPE(mm_setr_pd)                  \
     TYPE(mm_setzero_pd)               \
     TYPE(mm_setzero_si128)            \
+    TYPE(mm_shuffle_epi32)            \
+    TYPE(mm_shuffle_pd)               \
+    TYPE(mm_shufflehi_epi16)          \
+    TYPE(mm_shufflelo_epi16)          \
     TYPE(mm_sll_epi16)                \
     TYPE(mm_sll_epi32)                \
     TYPE(mm_sll_epi64)                \
@@ -227,6 +333,8 @@
     TYPE(mm_slli_epi32)               \
     TYPE(mm_slli_epi64)               \
     TYPE(mm_slli_si128)               \
+    TYPE(mm_sqrt_pd)                  \
+    TYPE(mm_sqrt_sd)                  \
     TYPE(mm_sra_epi16)                \
     TYPE(mm_sra_epi32)                \
     TYPE(mm_srai_epi16)               \
@@ -240,35 +348,61 @@
     TYPE(mm_srli_si128)               \
     TYPE(mm_store_pd)                 \
     TYPE(mm_store_pd1)                \
-    TYPE(mm_store1_pd)                \
+    TYPE(mm_store_sd)                 \
     TYPE(mm_store_si128)              \
+    TYPE(mm_store1_pd)                \
+    TYPE(mm_storeh_pd)                \
     TYPE(mm_storel_epi64)             \
+    TYPE(mm_storel_pd)                \
+    TYPE(mm_storer_pd)                \
     TYPE(mm_storeu_pd)                \
     TYPE(mm_storeu_si128)             \
+    TYPE(mm_storeu_si32)              \
+    TYPE(mm_stream_pd)                \
     TYPE(mm_stream_si128)             \
+    TYPE(mm_stream_si32)              \
+    TYPE(mm_stream_si64)              \
     TYPE(mm_sub_epi16)                \
     TYPE(mm_sub_epi32)                \
     TYPE(mm_sub_epi64)                \
     TYPE(mm_sub_epi8)                 \
+    TYPE(mm_sub_pd)                   \
+    TYPE(mm_sub_sd)                   \
     TYPE(mm_sub_si64)                 \
     TYPE(mm_subs_epi16)               \
     TYPE(mm_subs_epi8)                \
     TYPE(mm_subs_epu16)               \
     TYPE(mm_subs_epu8)                \
+    TYPE(mm_ucomieq_sd)               \
+    TYPE(mm_ucomige_sd)               \
+    TYPE(mm_ucomigt_sd)               \
+    TYPE(mm_ucomile_sd)               \
+    TYPE(mm_ucomilt_sd)               \
+    TYPE(mm_ucomineq_sd)              \
+    TYPE(mm_undefined_pd)             \
+    TYPE(mm_undefined_si128)          \
     TYPE(mm_unpackhi_epi16)           \
     TYPE(mm_unpackhi_epi32)           \
     TYPE(mm_unpackhi_epi64)           \
     TYPE(mm_unpackhi_epi8)            \
+    TYPE(mm_unpackhi_pd)              \
     TYPE(mm_unpacklo_epi16)           \
     TYPE(mm_unpacklo_epi32)           \
     TYPE(mm_unpacklo_epi64)           \
     TYPE(mm_unpacklo_epi8)            \
+    TYPE(mm_unpacklo_pd)              \
     TYPE(mm_xor_pd)                   \
     TYPE(mm_xor_si128)                \
     /* SSE3 */                        \
+    TYPE(mm_addsub_pd)                \
     TYPE(mm_addsub_ps)                \
+    TYPE(mm_hadd_pd)                  \
     TYPE(mm_hadd_ps)                  \
+    TYPE(mm_hsub_pd)                  \
     TYPE(mm_hsub_ps)                  \
+    TYPE(mm_lddqu_si128)              \
+    TYPE(mm_loaddup_pd)               \
+    TYPE(mm_movedup_pd)               \
     TYPE(mm_movehdup_ps)              \
     TYPE(mm_moveldup_ps)              \
     /* SSSE3 */                       \
@@ -278,17 +412,26 @@
     TYPE(mm_abs_pi16)                 \
     TYPE(mm_abs_pi32)                 \
     TYPE(mm_abs_pi8)                  \
+    TYPE(mm_alignr_epi8)              \
+    TYPE(mm_alignr_pi8)               \
     TYPE(mm_hadd_epi16)               \
     TYPE(mm_hadd_epi32)               \
     TYPE(mm_hadd_pi16)                \
     TYPE(mm_hadd_pi32)                \
     TYPE(mm_hadds_epi16)              \
+    TYPE(mm_hadds_pi16)               \
     TYPE(mm_hsub_epi16)               \
     TYPE(mm_hsub_epi32)               \
+    TYPE(mm_hsub_pi16)                \
+    TYPE(mm_hsub_pi32)                \
     TYPE(mm_hsubs_epi16)              \
+    TYPE(mm_hsubs_pi16)               \
     TYPE(mm_maddubs_epi16)            \
+    TYPE(mm_maddubs_pi16)             \
     TYPE(mm_mulhrs_epi16)             \
+    TYPE(mm_mulhrs_pi16)              \
     TYPE(mm_shuffle_epi8)             \
+    TYPE(mm_shuffle_pi8)              \
     TYPE(mm_sign_epi16)               \
     TYPE(mm_sign_epi32)               \
     TYPE(mm_sign_epi8)                \
@@ -297,10 +440,15 @@
     TYPE(mm_sign_pi8)                 \
     /* SSE4.1 */                      \
     TYPE(mm_blend_epi16)              \
+    TYPE(mm_blend_pd)                 \
+    TYPE(mm_blend_ps)                 \
     TYPE(mm_blendv_epi8)              \
     TYPE(mm_blendv_pd)                \
     TYPE(mm_blendv_ps)                \
+    TYPE(mm_ceil_pd)                  \
     TYPE(mm_ceil_ps)                  \
+    TYPE(mm_ceil_sd)                  \
+    TYPE(mm_ceil_ss)                  \
     TYPE(mm_cmpeq_epi64)              \
     TYPE(mm_cvtepi16_epi32)           \
     TYPE(mm_cvtepi16_epi64)           \
@@ -314,15 +462,20 @@
     TYPE(mm_cvtepu8_epi16)            \
     TYPE(mm_cvtepu8_epi32)            \
     TYPE(mm_cvtepu8_epi64)            \
+    TYPE(mm_dp_pd)                    \
     TYPE(mm_dp_ps)                    \
     TYPE(mm_extract_epi32)            \
     TYPE(mm_extract_epi64)            \
     TYPE(mm_extract_epi8)             \
     TYPE(mm_extract_ps)               \
+    TYPE(mm_floor_pd)                 \
     TYPE(mm_floor_ps)                 \
+    TYPE(mm_floor_sd)                 \
+    TYPE(mm_floor_ss)                 \
     TYPE(mm_insert_epi32)             \
     TYPE(mm_insert_epi64)             \
     TYPE(mm_insert_epi8)              \
+    TYPE(mm_insert_ps)                \
     TYPE(mm_max_epi32)                \
     TYPE(mm_max_epi8)                 \
     TYPE(mm_max_epu16)                \
@@ -332,17 +485,37 @@
     TYPE(mm_min_epu16)                \
     TYPE(mm_min_epu32)                \
     TYPE(mm_minpos_epu16)             \
+    TYPE(mm_mpsadbw_epu8)             \
     TYPE(mm_mul_epi32)                \
     TYPE(mm_mullo_epi32)              \
     TYPE(mm_packus_epi32)             \
+    TYPE(mm_round_pd)                 \
     TYPE(mm_round_ps)                 \
+    TYPE(mm_round_sd)                 \
+    TYPE(mm_round_ss)                 \
     TYPE(mm_stream_load_si128)        \
     TYPE(mm_test_all_ones)            \
     TYPE(mm_test_all_zeros)           \
+    TYPE(mm_test_mix_ones_zeros)      \
     TYPE(mm_testc_si128)              \
+    TYPE(mm_testnzc_si128)            \
     TYPE(mm_testz_si128)              \
     /* SSE4.2 */                      \
+    TYPE(mm_cmpestra)                 \
+    TYPE(mm_cmpestrc)                 \
+    TYPE(mm_cmpestri)                 \
+    TYPE(mm_cmpestrm)                 \
+    TYPE(mm_cmpestro)                 \
+    TYPE(mm_cmpestrs)                 \
+    TYPE(mm_cmpestrz)                 \
     TYPE(mm_cmpgt_epi64)              \
+    TYPE(mm_cmpistra)                 \
+    TYPE(mm_cmpistrc)                 \
+    TYPE(mm_cmpistri)                 \
+    TYPE(mm_cmpistrm)                 \
+    TYPE(mm_cmpistro)                 \
+    TYPE(mm_cmpistrs)                 \
+    TYPE(mm_cmpistrz)                 \
     TYPE(mm_crc32_u16)                \
     TYPE(mm_crc32_u32)                \
     TYPE(mm_crc32_u64)                \
@@ -357,12 +530,9 @@
     TYPE(mm_clmulepi64_si128)         \
     TYPE(mm_popcnt_u32)               \
     TYPE(mm_popcnt_u64)               \
-    TYPE(mm_shuffle_epi32)            \
     TYPE(mm_shuffle_epi32_default)    \
     TYPE(mm_shuffle_epi32_splat)      \
-    TYPE(mm_shufflehi_epi16)          \
     TYPE(mm_shufflehi_epi16_function) \
-    TYPE(mm_shufflelo_epi16)          \
     TYPE(mm_shufflelo_epi16_function) \
     TYPE(last) /* This indicates the end of macros */
 


### PR DESCRIPTION
Declare all the intrinsics in impl.h and add the corresponding tests
in impl.cpp with returning `TEST_UNIMPL`. The order of declarations in
impl.h is based on the order on official guide.