### PR TITLE
CI: Make sure the coding convention is checked

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -52,5 +52,7 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
       - name: coding convention
-        run: sh .ci/check-format.sh
+        run: |
+            sudo apt-get install -y clang-format-6.0
+            sh .ci/check-format.sh
         shell: bash

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2868,7 +2868,7 @@ result_t test_mm_cmpeq_pd(const SSE2NEONTestImpl &impl, uint32_t i)
     __m128d a = do_mm_load_pd(_a);
     __m128d b = do_mm_load_pd(_b);
     __m128d c = _mm_cmpeq_pd(a, b);
-    return validateDouble(c, *(double*) &d0, *(double*) &d1);
+    return validateDouble(c, *(double *) &d0, *(double *) &d1);
 }
 
 result_t test_mm_cmpgt_epi16(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The .ci/check-format script does not return error when
the clang-format-6.0 is not installed.
Currently, the commit makes sure the required software is installed.

The fixing of the script will be done in the future.