### PR TITLE
test: Call tests with the same implementation

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -4699,11 +4699,11 @@ FORCE_INLINE int _mm_comineq_ss(__m128 a, __m128 b)
 
 // according to the documentation, these intrinsics behave the same as the
 // non-'u' versions.  We'll just alias them here.
-#define _mm_ucomilt_ss _mm_comilt_ss
-#define _mm_ucomile_ss _mm_comile_ss
-#define _mm_ucomigt_ss _mm_comigt_ss
-#define _mm_ucomige_ss _mm_comige_ss
 #define _mm_ucomieq_ss _mm_comieq_ss
+#define _mm_ucomige_ss _mm_comige_ss
+#define _mm_ucomigt_ss _mm_comigt_ss
+#define _mm_ucomile_ss _mm_comile_ss
+#define _mm_ucomilt_ss _mm_comilt_ss
 #define _mm_ucomineq_ss _mm_comineq_ss
 
 /* Conversions */

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2467,32 +2467,38 @@ result_t test_mm_sub_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_ucomieq_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomieq_ss is equal to _mm_comieq_ss
+    return test_mm_comieq_ss(impl, i);
 }
 
 result_t test_mm_ucomige_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomige_ss is equal to _mm_comige_ss
+    return test_mm_comige_ss(impl, i);
 }
 
 result_t test_mm_ucomigt_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomigt_ss is equal to _mm_comigt_ss
+    return test_mm_comigt_ss(impl, i);
 }
 
 result_t test_mm_ucomile_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomile_ss is equal to _mm_comile_ss
+    return test_mm_comile_ss(impl, i);
 }
 
 result_t test_mm_ucomilt_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomilt_ss is equal to _mm_comilt_ss
+    return test_mm_comilt_ss(impl, i);
 }
 
 result_t test_mm_ucomineq_ss(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    // _mm_ucomineq_ss is equal to _mm_comineq_ss
+    return test_mm_comineq_ss(impl, i);
 }
 
 result_t test_mm_undefined_ps(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
_mm_ucomieq_ss, _mm_ucomige_ss, _mm_ucomigt_ss,_mm_ucomile_ss
,_mm_ucomilt_ss, _mm_ucomineq_ss share the same implementation of
_mm_comieq_ss, _mm_comige_ss, _mm_comigt_ss,_mm_comile_ss, _mm_comilt_ss
, _mm_comineq_ss.

Therefore, we can call the tests of _mm_comieq_ss, _mm_comige_ss,
_mm_comigt_ss,_mm_comile_ss, _mm_comilt_ss, _mm_comineq_ss directly.