### PR TITLE
feat: Implement _mm_blend_ps with test

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5350,6 +5350,23 @@ FORCE_INLINE __m128 _mm_blendv_ps(__m128 _a, __m128 _b, __m128 _mask)
     return vreinterpretq_m128_f32(vbslq_f32(mask, b, a));
 }
 
+
+// Blend packed single-precision (32-bit) floating-point elements from a and b
+// using mask, and store the results in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blend_ps
+FORCE_INLINE __m128 _mm_blend_ps(__m128 _a, __m128 _b, const char imm8)
+{
+    const uint32_t ALIGN_STRUCT(16)
+        data[4] = {((imm8) & (1 << 0)) ? UINT32_MAX : 0,
+                   ((imm8) & (1 << 1)) ? UINT32_MAX : 0,
+                   ((imm8) & (1 << 2)) ? UINT32_MAX : 0,
+                   ((imm8) & (1 << 3)) ? UINT32_MAX : 0};
+    uint32x4_t mask = vld1q_u32(data);
+    float32x4_t a = vreinterpretq_f32_m128(_a);
+    float32x4_t b = vreinterpretq_f32_m128(_b);
+    return vreinterpretq_m128_f32(vbslq_f32(mask, b, a));
+}
+
 // Blend packed double-precision (64-bit) floating-point elements from a and b
 // using mask, and store the results in dst.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blendv_pd

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -6175,6 +6175,9 @@ result_t test_mm_blend_pd(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 {
+// gcc and clang can't compile call to _mm_blend_ps with 3rd argument as integer type due 4 bit constatnt size limitation
+// and test framework doesn't support compile time constant
+// but on target platform its complie , run and passed    
 #if __x86_64__
     return TEST_UNIMPL;
 #else

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -6175,12 +6175,6 @@ result_t test_mm_blend_pd(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-// gcc and clang can't compile call to _mm_blend_ps with 3rd argument as integer type due 4 bit constatnt size limitation
-// and test framework doesn't support compile time constant
-// but on target platform its complie , run and passed    
-#if __x86_64__
-    return TEST_UNIMPL;
-#else
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
 
@@ -6198,10 +6192,65 @@ result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t i)
     __m128 a = do_mm_load_ps(_a);
     __m128 b = do_mm_load_ps(_b);
 
-    __m128 c = _mm_blend_ps(a, b, (mask & 0xF));
+    // gcc and clang can't compile call to _mm_blend_ps with 3rd argument as
+    // integer type due 4 bit size limitation and test framework doesn't support
+    // compile time constant so for testing decided explicit define all 16
+    // possible values
+    __m128 c;
+    switch (mask & 0xF) {
+    case 0:
+        c = _mm_blend_ps(a, b, 0);
+        break;
+    case 1:
+        c = _mm_blend_ps(a, b, 1);
+        break;
+    case 2:
+        c = _mm_blend_ps(a, b, 2);
+        break;
+    case 3:
+        c = _mm_blend_ps(a, b, 3);
+        break;
 
+    case 4:
+        c = _mm_blend_ps(a, b, 4);
+        break;
+    case 5:
+        c = _mm_blend_ps(a, b, 5);
+        break;
+    case 6:
+        c = _mm_blend_ps(a, b, 6);
+        break;
+    case 7:
+        c = _mm_blend_ps(a, b, 7);
+        break;
+
+    case 8:
+        c = _mm_blend_ps(a, b, 8);
+        break;
+    case 9:
+        c = _mm_blend_ps(a, b, 9);
+        break;
+    case 10:
+        c = _mm_blend_ps(a, b, 10);
+        break;
+    case 11:
+        c = _mm_blend_ps(a, b, 11);
+        break;
+
+    case 12:
+        c = _mm_blend_ps(a, b, 12);
+        break;
+    case 13:
+        c = _mm_blend_ps(a, b, 13);
+        break;
+    case 14:
+        c = _mm_blend_ps(a, b, 14);
+        break;
+    case 15:
+        c = _mm_blend_ps(a, b, 15);
+        break;
+    }
     return validateFloat(c, _c[0], _c[1], _c[2], _c[3]);
-#endif
 }
 
 result_t test_mm_blendv_epi8(const SSE2NEONTestImpl &impl, uint32_t i)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -6175,7 +6175,30 @@ result_t test_mm_blend_pd(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 {
+#if __x86_64__
     return TEST_UNIMPL;
+#else
+    const float *_a = impl.mTestFloatPointer1;
+    const float *_b = impl.mTestFloatPointer2;
+
+    const char mask = (char) i;
+
+    float _c[4];
+    for (int i = 0; i < 4; i++) {
+        if (mask & (1 << i)) {
+            _c[i] = _b[i];
+        } else {
+            _c[i] = _a[i];
+        }
+    }
+
+    __m128 a = do_mm_load_ps(_a);
+    __m128 b = do_mm_load_ps(_b);
+
+    __m128 c = _mm_blend_ps(a, b, (mask & 0xF));
+
+    return validateFloat(c, _c[0], _c[1], _c[2], _c[3]);
+#endif
 }
 
 result_t test_mm_blendv_epi8(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_blend_ps
tested on NVIDIA XAVIAR
test for x86 disable due immediate 4 bit restriction 