### PR TITLE
fix: Fix _mm_alignr_epi8 implementation and add test

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <utility>
 #include "binding.h"
 
@@ -5744,7 +5745,36 @@ result_t test_mm_abs_pi8(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t i)
 {
+#if defined(__clang__)
     return TEST_UNIMPL;
+#else
+    const uint8_t *_a = (const uint8_t *) impl.mTestIntPointer1;
+    const uint8_t *_b = (const uint8_t *) impl.mTestIntPointer2;
+    // FIXME: The different immediate value should be tested in the future
+    const int shift = 18;
+    uint8_t d[32];
+
+    if (shift >= 32) {
+        memset((void *) d, 0, sizeof(d));
+    } else {
+        memcpy((void *) d, (const void *) _b, 16);
+        memcpy((void *) (d + 16), (const void *) _a, 16);
+        // shifting
+        for (uint x = 0; x < sizeof(d); x++) {
+            if (x + shift >= sizeof(d))
+                d[x] = 0;
+            else
+                d[x] = d[x + shift];
+        }
+    }
+
+    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i ret = _mm_alignr_epi8(a, b, shift);
+
+    return validateUInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
+                         d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]);
+#endif
 }
 
 result_t test_mm_alignr_pi8(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The original version does not accept the third argument of
_mm_alignr_epi8 larger than 15 with GCC.

However, the fixed version still has the problem on ARM platform with
Clang-10.
Clang-10 would check the third argument of vextq_u8 in different if-else
condition and generate error message "argument value is outside the
valid range [0, 15]".