### PR TITLE
test: Add tests for _m_pavgb and _m_pavgw

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2044,12 +2044,12 @@ result_t test_mm_or_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_m_pavgb(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_avg_pu8(impl, i);
 }
 
 result_t test_m_pavgw(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_avg_pu16(impl, i);
 }
 
 result_t test_m_pextrw(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
`_m_pavgb` and `_m_pavgw` share the same implementation of
`_mm_avg_pu8` and `_mm_avg_pu16`, respectively, so we can simply call
the tests of `_mm_avg_pu8` and `_mm_avg_pu16`.