### PR TITLE
feat: Implement intrinsics with the corresponding intrinsics

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -3165,6 +3165,31 @@ FORCE_INLINE __m64 _mm_avg_pu8(__m64 a, __m64 b)
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_m_pextrw
 #define _m_pextrw(a, imm) _mm_extract_pi16(a, imm)
 
+// Copy a to dst, and insert the 16-bit integer i into dst at the location
+// specified by imm8.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=m_pinsrw
+#define _m_pinsrw(a, i, imm) _mm_insert_pi16(a, i, imm)
+
+// Compare packed signed 16-bit integers in a and b, and store packed maximum
+// values in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_m_pmaxsw
+#define _m_pmaxsw(a, b) _mm_max_pi16(a, b)
+
+// Compare packed unsigned 8-bit integers in a and b, and store packed maximum
+// values in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_m_pmaxub
+#define _m_pmaxub(a, b) _mm_max_pu8(a, b)
+
+// Compare packed signed 16-bit integers in a and b, and store packed minimum
+// values in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_m_pminsw
+#define _m_pminsw(a, b) _mm_min_pi16(a, b)
+
+// Compare packed unsigned 8-bit integers in a and b, and store packed minimum
+// values in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_m_pminub
+#define _m_pminub(a, b) _mm_min_pu8(a, b)
+
 // Computes the average of the 16 unsigned 8-bit integers in a and the 16
 // unsigned 8-bit integers in b and rounds.
 //

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2058,27 +2058,27 @@ result_t test_m_pextrw(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_m_pinsrw(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_insert_pi16(impl, i);
 }
 
 result_t test_m_pmaxsw(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_max_pi16(impl, i);
 }
 
 result_t test_m_pmaxub(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_max_pu8(impl, i);
 }
 
 result_t test_m_pminsw(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_min_pi16(impl, i);
 }
 
 result_t test_m_pminub(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_min_pu8(impl, i);
 }
 
 result_t test_m_pmovmskb(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The intrinsics which are implemented in this PR, actually share the
same implementation listed as following, so we use the implemtation
directly.

"_m_pinsrw": "_mm_insert_pi16"
"_m_pmaxsw": "_mm_max_pi16"
"_m_pmaxub": "_mm_max_pu8"
"_m_pminsw": "_mm_min_pi16"
"_m_pminub": "_mm_min_pu8"