### PR TITLE
feat: Implement _mm_cvtsd_si64[x]

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5731,6 +5731,23 @@ FORCE_INLINE double _mm_cvtsd_f64(__m128d a)
 #endif
 }
 
+// Convert the lower double-precision (64-bit) floating-point element in a to a
+// 64-bit integer, and store the result in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtsd_si64
+FORCE_INLINE int64_t _mm_cvtsd_si64(__m128d a)
+{
+#if defined(__aarch64__)
+    return (int64_t) vcvt_s64_f64(vget_low_f64(vreinterpretq_f64_m128d(a)));
+#else
+    return (int64_t)((double *) &a)[0];
+#endif
+}
+
+// Convert the lower double-precision (64-bit) floating-point element in a to a
+// 64-bit integer, and store the result in dst.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_cvtsd_si64x
+#define _mm_cvtsd_si64x(a) _mm_cvtsd_si64(a)
+
 // Convert packed single-precision (32-bit) floating-point elements in a to
 // packed double-precision (64-bit) floating-point elements, and store the
 // results in dst.

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3674,7 +3674,7 @@ result_t test_mm_cvtsd_si64(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_cvtsd_si64x(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_cvtsd_si64(impl, i);
 }
 
 result_t test_mm_cvtsd_ss(const SSE2NEONTestImpl &impl, uint32_t i)
@@ -3708,7 +3708,7 @@ result_t test_mm_cvtsi128_si64(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_cvtsi128_si64x(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    return test_mm_cvtsi128_si64(impl, i);
 }
 
 result_t test_mm_cvtsi32_sd(const SSE2NEONTestImpl &impl, uint32_t i)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3669,7 +3669,24 @@ result_t test_mm_cvtsd_si32(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_cvtsd_si64(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const double *_a = (const double *) impl.mTestFloatPointer1;
+    // NEON intrinsic "vcvt_s64_f64()" uses rounding mode "Rounding To Zero"
+    // which is defferent from the rounding mode on x86 system, so we need to
+    // apply different testing case here
+    // see:
+    // https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics?search=vcvt_s64_f64
+    // and
+    // https://software.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-streaming-simd-extensions-2-intel-sse2/integer-intrinsics/conversion-intrinsics-1.html
+#if defined(__x86_64__)
+    int64_t _c = (int64_t) round(_a[0]);
+#else
+    int64_t _c = (int64_t) _a[0];
+#endif
+
+    __m128d a = do_mm_load_pd(_a);
+    int64_t c = _mm_cvtsd_si64(a);
+
+    return _c == c ? TEST_SUCCESS : TEST_FAIL;
 }
 
 result_t test_mm_cvtsd_si64x(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
The behaviour of _mm_cvtsd_si64x and _mm_cvtsi128_si64x are the same
as the behaviour of _mm_cvtsd_si64 and _mm_cvtsi128_si64, respectively.

Therefore, we can run the test of the non-x-suffix.