### PR TITLE
feat: Implement _mm_storeu_si<16-64>

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -955,11 +955,32 @@ FORCE_INLINE void _mm_store_si128(__m128i *p, __m128i a)
     vst1q_s32((int32_t *) p, vreinterpretq_s32_m128i(a));
 }
 
-// Stores four 32-bit integer values as (as a __m128i value) at the address p.
-// https://msdn.microsoft.com/en-us/library/vstudio/edk11s13(v=vs.100).aspx
+// Stores 128-bits of integer data a at the address p.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_storeu_si128
 FORCE_INLINE void _mm_storeu_si128(__m128i *p, __m128i a)
 {
     vst1q_s32((int32_t *) p, vreinterpretq_s32_m128i(a));
+}
+
+// Stores 64-bits of integer data a at the address p.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_storeu_si64
+FORCE_INLINE void _mm_storeu_si64(void *p, __m128i a)
+{
+    vst1q_lane_s64((int64_t *) p, vreinterpretq_s64_m128i(a), 0);
+}
+
+// Stores 32-bits of integer data a at the address p.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_storeu_si32
+FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
+{
+    vst1q_lane_s32((int32_t *) p, vreinterpretq_s32_m128i(a), 0);
+}
+
+// Stores 16-bits of integer data a at the address p.
+// https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_storeu_si16
+FORCE_INLINE void _mm_storeu_si16(void *p, __m128i a)
+{
+    vst1q_lane_s16((int16_t *) p, vreinterpretq_s16_m128i(a), 0);
 }
 
 // Stores the lower single - precision, floating - point value.

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2568,12 +2568,32 @@ result_t test_mm_storeu_ps(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_storeu_si16(const SSE2NEONTestImpl &impl, uint32_t i)
 {
+    // The GCC version before 11 does not implement intrinsic function
+    // _mm_storeu_si16. Check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483
+    // for more information.
+#if defined(__GNUC__) && __GNUC__ <= 10
     return TEST_UNIMPL;
+#else
+    const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
+    __m128i b;
+    __m128i a = do_mm_load_ps(_a);
+    _mm_storeu_si16(&b, a);
+    int16_t *_b = (int16_t *) &b;
+    int16_t *_c = (int16_t *) &a;
+    return validateInt16(b, _c[0], _b[1], _b[2], _b[3], _b[4], _b[5], _b[6],
+                         _b[7]);
+#endif
 }
 
 result_t test_mm_storeu_si64(const SSE2NEONTestImpl &impl, uint32_t i)
 {
-    return TEST_UNIMPL;
+    const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
+    __m128i b;
+    __m128i a = do_mm_load_ps(_a);
+    _mm_storeu_si64(&b, a);
+    int64_t *_b = (int64_t *) &b;
+    int64_t *_c = (int64_t *) &a;
+    return validateInt64(b, _c[0], _b[1]);
 }
 
 result_t test_mm_stream_pi(const SSE2NEONTestImpl &impl, uint32_t i)
@@ -5337,7 +5357,7 @@ result_t test_mm_storeu_si128(const SSE2NEONTestImpl &impl, uint32_t i)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     __m128i b;
-    __m128i a = _mm_loadu_si128((const __m128i *) _a);
+    __m128i a = do_mm_load_ps(_a);
     _mm_storeu_si128(&b, a);
     int32_t *_b = (int32_t *) &b;
     return validateInt32(a, _b[0], _b[1], _b[2], _b[3]);
@@ -5345,7 +5365,19 @@ result_t test_mm_storeu_si128(const SSE2NEONTestImpl &impl, uint32_t i)
 
 result_t test_mm_storeu_si32(const SSE2NEONTestImpl &impl, uint32_t i)
 {
+    // The GCC version before 11 does not implement intrinsic function
+    // _mm_storeu_si32. Check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483
+    // for more information.
+#if defined(__GNUC__) && __GNUC__ <= 10
     return TEST_UNIMPL;
+#else
+    const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
+    __m128i b;
+    __m128i a = do_mm_load_ps(_a);
+    _mm_storeu_si32(&b, a);
+    int32_t *_b = (int32_t *) &b;
+    return validateInt32(b, _a[0], _b[1], _b[2], _b[3]);
+#endif
 }
 
 result_t test_mm_stream_pd(const SSE2NEONTestImpl &impl, uint32_t i)


### PR DESCRIPTION
GCC version before 11 does not implement intrinsic functions
_mm_storeu_si16 and _mm_storeu_si32.
The testing should be modified after the GCC 11 releases.
Check https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95483 for the
bug information.