### PR TITLE
fix: Add correct GCC version checking of vld1q_u8_x4

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -343,10 +343,10 @@ typedef union ALIGN_STRUCT(16) SIMDVec {
 /* Backwards compatibility for compilers with lack of specific type support */
 
 // Older gcc does not define vld1q_u8_x4 type
-#if defined(__GNUC__) && !defined(__clang__) &&   \
-    ((__GNUC__ == 10 && (__GNUC_MINOR__ <= 1)) || \
-     (__GNUC__ == 9 && (__GNUC_MINOR__ <= 3)) ||  \
-     (__GNUC__ == 8 && (__GNUC_MINOR__ <= 4)) || __GNUC__ <= 7)
+#if defined(__GNUC__) && !defined(__clang__) &&                        \
+    ((__GNUC__ <= 10 && defined(__arm__)) ||                           \
+     (__GNUC__ == 10 && __GNUC_MINOR__ < 3 && defined(__aarch64__)) || \
+     (__GNUC__ <= 9 && defined(__aarch64__)))
 FORCE_INLINE uint8x16x4_t _sse2neon_vld1q_u8_x4(const uint8_t *p)
 {
     uint8x16x4_t ret;


### PR DESCRIPTION
The comment of GCC bug in 2021-01-12 said that the intrinsic
vld1q_u8_x4 is not implemented in GCC.
Ref:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71233#c73

However, the GCC 10.3 released in 2021-04-08 has fixed the problem for
AArch64 CPU architecture, not for ARM CPU architecture.
Ref:
https://github.com/gcc-mirror/gcc/commit/391625888d4d97f9016ab9ac04acc55d81f0c26f

The Github Actions CI has change the GCC compiler from 10.1 to 10.3,
hence we should take care of the version well.