### PR TITLE
CI: Show the difference before and after clang-format

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -5,4 +5,9 @@ SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|h)\$" | egrep -v
 
 set -x
 
+for file in ${SOURCES};
+do
+    clang-format-6.0 ${file} > expected-format
+    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
+done
 exit $(clang-format-6.0 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")


### PR DESCRIPTION
The commit is for the developers who can not install the
clang-format-6.0.
They can view the correct coding style from the Github Actions CI.