### PR TITLE
refactor: Replace conditional op with binary operation

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1244,7 +1244,7 @@ FORCE_INLINE int _mm_comieq_ss(__m128 a, __m128 b)
     uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_eq_b =
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_eq_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_eq_b), 0) & 0x1;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -1261,7 +1261,7 @@ FORCE_INLINE int _mm_comige_ss(__m128 a, __m128 b)
     uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_ge_b =
         vcgeq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_ge_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_ge_b), 0) & 0x1;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -1278,7 +1278,7 @@ FORCE_INLINE int _mm_comigt_ss(__m128 a, __m128 b)
     uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_gt_b =
         vcgtq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_gt_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_gt_b), 0) & 0x1;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -1295,7 +1295,7 @@ FORCE_INLINE int _mm_comile_ss(__m128 a, __m128 b)
     uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_le_b =
         vcleq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_le_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_le_b), 0) & 0x1;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -1312,7 +1312,7 @@ FORCE_INLINE int _mm_comilt_ss(__m128 a, __m128 b)
     uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
     uint32x4_t a_lt_b =
         vcltq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b));
-    return (vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_lt_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_lt_b), 0) & 0x1;
 }
 
 // Compares the lower single-precision floating point scalar values of a and b
@@ -1329,7 +1329,7 @@ FORCE_INLINE int _mm_comineq_ss(__m128 a, __m128 b)
     uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
     uint32x4_t a_neq_b = vmvnq_u32(
         vceqq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
-    return (vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_neq_b), 0) != 0) ? 1 : 0;
+    return vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_neq_b), 0) & 0x1;
 }
 
 // Convert packed signed 32-bit integers in b to packed single-precision
@@ -7490,8 +7490,7 @@ FORCE_INLINE int _mm_test_all_zeros(__m128i a, __m128i mask)
 {
     int64x2_t a_and_mask =
         vandq_s64(vreinterpretq_s64_m128i(a), vreinterpretq_s64_m128i(mask));
-    return (vgetq_lane_s64(a_and_mask, 0) | vgetq_lane_s64(a_and_mask, 1)) ? 0
-                                                                           : 1;
+    return !(vgetq_lane_s64(a_and_mask, 0) | vgetq_lane_s64(a_and_mask, 1));
 }
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and b,


### PR DESCRIPTION
Some conditional operations can be replaced with binary operations
which should be able to accelerate the functions by removing branch
prediction.