### PR TITLE
Drop FMA intrinsic

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -8776,12 +8776,6 @@ result_t test_mm_aeskeygenassist_si128(const SSE2NEONTestImpl &impl,
     return validate128(resultReference, resultIntrinsic);
 }
 
-/* FMA */
-result_t test_mm_fmadd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
-{
-    return TEST_UNIMPL;
-}
-
 /* Others */
 result_t test_mm_clmulepi64_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -526,8 +526,6 @@
     TYPE(mm_aesenc_si128)          \
     TYPE(mm_aesenclast_si128)      \
     TYPE(mm_aeskeygenassist_si128) \
-    /* FMA */                      \
-    TYPE(mm_fmadd_ps)              \
     /* Others */                   \
     TYPE(mm_clmulepi64_si128)      \
     TYPE(mm_popcnt_u32)            \


### PR DESCRIPTION
Danila Kutenin pointed out:
> Technically speaking, _mm_fmadd_ps is not an SSE extension, this was
> introduced with fma extension which took place even after AVX.

To clarify the purpose of SSE2NEON, this pach would drop the existing
FMA implementation.

Related: #82