### PR TITLE
test: Change loading functions to non-aligned version

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -254,7 +254,7 @@ __m128i do_mm_set_epi32(int32_t x, int32_t y, int32_t z, int32_t w)
 
 // This function is not called from `runSingleTest`, but for other intrinsic
 // tests that might need to load __m64 data.
-__m64 do_mm_load_m64(const int64_t *p)
+__m64 load_m64(const int64_t *p)
 {
     __m64 a = *((const __m64 *) p);
     validateInt64(a, p[0]);
@@ -263,18 +263,18 @@ __m64 do_mm_load_m64(const int64_t *p)
 
 // This function is not called from `runSingleTest`, but for other intrinsic
 // tests that might need to call `_mm_load_ps`.
-__m128 do_mm_load_ps(const float *p)
+__m128 load_m128(const float *p)
 {
-    __m128 a = _mm_load_ps(p);
+    __m128 a = _mm_loadu_ps(p);
     validateFloat(a, p[0], p[1], p[2], p[3]);
     return a;
 }
 
 // This function is not called from `runSingleTest`, but for other intrinsic
 // tests that might need to call `_mm_load_ps`.
-__m128i do_mm_load_ps(const int32_t *p)
+__m128i load_m128i(const int32_t *p)
 {
-    __m128 a = _mm_load_ps((const float *) p);
+    __m128 a = _mm_loadu_ps((const float *) p);
     __m128i ia = *(const __m128i *) &a;
     validateInt32(ia, p[0], p[1], p[2], p[3]);
     return ia;
@@ -282,9 +282,9 @@ __m128i do_mm_load_ps(const int32_t *p)
 
 // This function is not called from `runSingleTest`, but for other intrinsic
 // tests that might need to call `_mm_load_pd`.
-__m128d do_mm_load_pd(const double *p)
+__m128d load_m128d(const double *p)
 {
-    __m128d a = _mm_load_pd(p);
+    __m128d a = _mm_loadu_pd(p);
     validateDouble(a, p[0], p[1]);
     return a;
 }
@@ -654,8 +654,8 @@ result_t test_mm_add_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2] + _b[2];
     float dw = _a[3] + _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_add_ps(a, b);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -681,8 +681,8 @@ result_t test_mm_and_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_and_ps(a, b);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
@@ -709,8 +709,8 @@ result_t test_mm_andnot_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_andnot_ps(a, b);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
@@ -736,8 +736,8 @@ result_t test_mm_avg_pu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d2 = (_a[2] + _b[2] + 1) >> 1;
     uint16_t d3 = (_a[3] + _b[3] + 1) >> 1;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_avg_pu16(a, b);
 
     return validateUInt16(c, d0, d1, d2, d3);
@@ -756,8 +756,8 @@ result_t test_mm_avg_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint8_t d6 = (_a[6] + _b[6] + 1) >> 1;
     uint8_t d7 = (_a[7] + _b[7] + 1) >> 1;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_avg_pu8(a, b);
 
     return validateUInt8(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -767,8 +767,8 @@ result_t test_mm_cmpeq_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] == _b[0] ? -1 : 0;
@@ -785,8 +785,8 @@ result_t test_mm_cmpeq_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] == _b[0] ? ALL_BIT_1_32 : 0;
@@ -802,8 +802,8 @@ result_t test_mm_cmpge_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] >= _b[0] ? -1 : 0;
@@ -820,8 +820,8 @@ result_t test_mm_cmpge_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] >= _b[0] ? ALL_BIT_1_32 : 0;
@@ -837,8 +837,8 @@ result_t test_mm_cmpgt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] > _b[0] ? -1 : 0;
@@ -855,8 +855,8 @@ result_t test_mm_cmpgt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] > _b[0] ? ALL_BIT_1_32 : 0;
@@ -872,8 +872,8 @@ result_t test_mm_cmple_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] <= _b[0] ? -1 : 0;
@@ -890,8 +890,8 @@ result_t test_mm_cmple_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] <= _b[0] ? ALL_BIT_1_32 : 0;
@@ -907,8 +907,8 @@ result_t test_mm_cmplt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] < _b[0] ? -1 : 0;
@@ -926,8 +926,8 @@ result_t test_mm_cmplt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] < _b[0] ? ALL_BIT_1_32 : 0;
@@ -943,8 +943,8 @@ result_t test_mm_cmpneq_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result[4];
     result[0] = _a[0] != _b[0] ? -1 : 0;
@@ -961,8 +961,8 @@ result_t test_mm_cmpneq_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = _a[0] != _b[0] ? ALL_BIT_1_32 : 0;
@@ -978,8 +978,8 @@ result_t test_mm_cmpnge_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] >= _b[0]) ? ALL_BIT_1_32 : 0;
@@ -995,8 +995,8 @@ result_t test_mm_cmpnge_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] >= _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1012,8 +1012,8 @@ result_t test_mm_cmpngt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] > _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1029,8 +1029,8 @@ result_t test_mm_cmpngt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] > _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1046,8 +1046,8 @@ result_t test_mm_cmpnle_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] <= _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1063,8 +1063,8 @@ result_t test_mm_cmpnle_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] <= _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1080,8 +1080,8 @@ result_t test_mm_cmpnlt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] < _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1097,8 +1097,8 @@ result_t test_mm_cmpnlt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = !(_a[0] < _b[0]) ? ALL_BIT_1_32 : 0;
@@ -1114,8 +1114,8 @@ result_t test_mm_cmpord_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
 
@@ -1132,8 +1132,8 @@ result_t test_mm_cmpord_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = compord(_a[0], _b[0]);
@@ -1150,8 +1150,8 @@ result_t test_mm_cmpunord_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
 
@@ -1168,8 +1168,8 @@ result_t test_mm_cmpunord_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = (isNAN(_a[0]) || isNAN(_b[0])) ? getNAN() : 0.0f;
@@ -1187,8 +1187,8 @@ result_t test_mm_comieq_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     if (isNAN(_a[0]) || isNAN(_b[0]))
         // Test disabled: GCC and Clang on x86_64 return different values.
@@ -1204,8 +1204,8 @@ result_t test_mm_comige_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result = comige_ss(_a[0], _b[0]);
     int32_t ret = _mm_comige_ss(a, b);
@@ -1217,8 +1217,8 @@ result_t test_mm_comigt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     int32_t result = comigt_ss(_a[0], _b[0]);
     int32_t ret = _mm_comigt_ss(a, b);
@@ -1230,8 +1230,8 @@ result_t test_mm_comile_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     if (isNAN(_a[0]) || isNAN(_b[0]))
         // Test disabled: GCC and Clang on x86_64 return different values.
@@ -1247,8 +1247,8 @@ result_t test_mm_comilt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     if (isNAN(_a[0]) || isNAN(_b[0]))
         // Test disabled: GCC and Clang on x86_64 return different values.
@@ -1265,8 +1265,8 @@ result_t test_mm_comineq_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     if (isNAN(_a[0]) || isNAN(_b[0]))
         // Test disabled: GCC and Clang on x86_64 return different values.
@@ -1288,8 +1288,8 @@ result_t test_mm_cvt_pi2ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m128 a = load_m128(_a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m128 c = _mm_cvt_pi2ps(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1321,7 +1321,7 @@ result_t test_mm_cvt_ps2pi(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvt_ps2pi(a);
 
     return validateInt32(ret, d[0], d[1]);
@@ -1337,7 +1337,7 @@ result_t test_mm_cvt_si2ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_cvt_si2ss(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1367,7 +1367,7 @@ result_t test_mm_cvt_ss2si(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int32_t ret = _mm_cvt_ss2si(a);
     return ret == d0 ? TEST_SUCCESS : TEST_FAIL;
 }
@@ -1381,7 +1381,7 @@ result_t test_mm_cvtpi16_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = (float) _a[2];
     float dw = (float) _a[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m128 c = _mm_cvtpi16_ps(a);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1397,8 +1397,8 @@ result_t test_mm_cvtpi32_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m128 a = load_m128(_a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m128 c = _mm_cvtpi32_ps(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1414,8 +1414,8 @@ result_t test_mm_cvtpi32x2_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = (float) _b[0];
     float dw = (float) _b[1];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m128 c = _mm_cvtpi32x2_ps(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1430,7 +1430,7 @@ result_t test_mm_cvtpi8_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = (float) _a[2];
     float dw = (float) _a[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m128 c = _mm_cvtpi8_ps(a);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1468,7 +1468,7 @@ result_t test_mm_cvtps_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvtps_pi16(a);
     return validateInt16(ret, rnd[0], rnd[1], rnd[2], rnd[3]);
 }
@@ -1501,7 +1501,7 @@ result_t test_mm_cvtps_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvtps_pi32(a);
 
     return validateInt32(ret, d[0], d[1]);
@@ -1539,7 +1539,7 @@ result_t test_mm_cvtps_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvtps_pi8(a);
     return validateInt8(ret, rnd[0], rnd[1], rnd[2], rnd[3], 0, 0, 0, 0);
 }
@@ -1553,7 +1553,7 @@ result_t test_mm_cvtpu16_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = (float) _a[2];
     float dw = (float) _a[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m128 c = _mm_cvtpu16_ps(a);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1568,7 +1568,7 @@ result_t test_mm_cvtpu8_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = (float) _a[2];
     float dw = (float) _a[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m128 c = _mm_cvtpu8_ps(a);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1584,7 +1584,7 @@ result_t test_mm_cvtsi32_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_cvtsi32_ss(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1600,7 +1600,7 @@ result_t test_mm_cvtsi64_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_cvtsi64_ss(a, b);
 
     return validateFloat(c, dx, dy, dz, dw);
@@ -1612,7 +1612,7 @@ result_t test_mm_cvtss_f32(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     float f = _a[0];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     float c = _mm_cvtss_f32(a);
 
     return f == c ? TEST_SUCCESS : TEST_FAIL;
@@ -1642,7 +1642,7 @@ result_t test_mm_cvtss_si32(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int32_t ret = _mm_cvtss_si32(a);
 
     return ret == d0 ? TEST_SUCCESS : TEST_FAIL;
@@ -1672,7 +1672,7 @@ result_t test_mm_cvtss_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int64_t ret = _mm_cvtss_si64(a);
 
     return ret == d0 ? TEST_SUCCESS : TEST_FAIL;
@@ -1686,7 +1686,7 @@ result_t test_mm_cvtt_ps2pi(const SSE2NEONTestImpl &impl, uint32_t iter)
     d[0] = (int32_t) _a[0];
     d[1] = (int32_t) _a[1];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvtt_ps2pi(a);
 
     return validateInt32(ret, d[0], d[1]);
@@ -1696,7 +1696,7 @@ result_t test_mm_cvtt_ss2si(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int ret = _mm_cvtt_ss2si(a);
 
     return ret == (int32_t) _a[0] ? TEST_SUCCESS : TEST_FAIL;
@@ -1710,7 +1710,7 @@ result_t test_mm_cvttps_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     d[0] = (int32_t) _a[0];
     d[1] = (int32_t) _a[1];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m64 ret = _mm_cvttps_pi32(a);
 
     return validateInt32(ret, d[0], d[1]);
@@ -1720,7 +1720,7 @@ result_t test_mm_cvttss_si32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int ret = _mm_cvttss_si32(a);
 
     return ret == (int32_t) _a[0] ? TEST_SUCCESS : TEST_FAIL;
@@ -1730,7 +1730,7 @@ result_t test_mm_cvttss_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int64_t ret = _mm_cvttss_si64(a);
 
     return ret == (int64_t) _a[0] ? TEST_SUCCESS : TEST_FAIL;
@@ -1745,8 +1745,8 @@ result_t test_mm_div_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2] / _b[2];
     float f3 = _a[3] / _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_div_ps(a, b);
 
 #if defined(__arm__) && !defined(__aarch64__)
@@ -1769,8 +1769,8 @@ result_t test_mm_div_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float d2 = _a[2];
     float d3 = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_div_ss(a, b);
 
 #if defined(__arm__) && !defined(__aarch64__)
@@ -1793,7 +1793,7 @@ result_t test_mm_extract_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t *_a = (uint64_t *) impl.mTestIntPointer1;
     const int idx = iter & 0x3;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     int c;
     switch (idx) {
     case 0:
@@ -1859,7 +1859,7 @@ result_t test_mm_insert_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
     d[imm8] = insert;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m64 b = _mm_insert_pi16(a, insert, imm8);
 
     return validateInt16(b, d[0], d[1], d[2], d[3]);
@@ -2014,8 +2014,8 @@ result_t test_mm_max_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[2] = _a[2] > _b[2] ? _a[2] : _b[2];
     c[3] = _a[3] > _b[3] ? _a[3] : _b[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_max_pi16(a, b);
     return validateInt16(ret, c[0], c[1], c[2], c[3]);
 }
@@ -2031,8 +2031,8 @@ result_t test_mm_max_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[2] = _a[2] > _b[2] ? _a[2] : _b[2];
     c[3] = _a[3] > _b[3] ? _a[3] : _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 ret = _mm_max_ps(a, b);
     return validateFloat(ret, c[0], c[1], c[2], c[3]);
 }
@@ -2052,8 +2052,8 @@ result_t test_mm_max_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[6] = _a[6] > _b[6] ? _a[6] : _b[6];
     c[7] = _a[7] > _b[7] ? _a[7] : _b[7];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_max_pu8(a, b);
     return validateUInt8(ret, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]);
 }
@@ -2086,8 +2086,8 @@ result_t test_mm_min_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[2] = _a[2] < _b[2] ? _a[2] : _b[2];
     c[3] = _a[3] < _b[3] ? _a[3] : _b[3];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_min_pi16(a, b);
     return validateInt16(ret, c[0], c[1], c[2], c[3]);
 }
@@ -2103,8 +2103,8 @@ result_t test_mm_min_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[2] = _a[2] < _b[2] ? _a[2] : _b[2];
     c[3] = _a[3] < _b[3] ? _a[3] : _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 ret = _mm_min_ps(a, b);
     return validateFloat(ret, c[0], c[1], c[2], c[3]);
 }
@@ -2124,8 +2124,8 @@ result_t test_mm_min_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     c[6] = _a[6] < _b[6] ? _a[6] : _b[6];
     c[7] = _a[7] < _b[7] ? _a[7] : _b[7];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_min_pu8(a, b);
     return validateUInt8(ret, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]);
 }
@@ -2138,8 +2138,8 @@ result_t test_mm_min_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     c = _a[0] < _b[0] ? _a[0] : _b[0];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 ret = _mm_min_ss(a, b);
 
     return validateFloat(ret, c, _a[1], _a[2], _a[3]);
@@ -2149,8 +2149,8 @@ result_t test_mm_move_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     float result[4];
     result[0] = b[0];
@@ -2172,8 +2172,8 @@ result_t test_mm_movehl_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2];
     float f3 = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 ret = _mm_movehl_ps(a, b);
 
     return validateFloat(ret, f0, f1, f2, f3);
@@ -2189,8 +2189,8 @@ result_t test_mm_movelh_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _b[0];
     float f3 = _b[1];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 ret = _mm_movelh_ps(a, b);
 
     return validateFloat(ret, f0, f1, f2, f3);
@@ -2231,7 +2231,7 @@ result_t test_mm_movemask_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (ip[3] & 0x80000000) {
         ret |= 8;
     }
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     int val = _mm_movemask_ps(a);
     return val == ret ? TEST_SUCCESS : TEST_FAIL;
 }
@@ -2245,8 +2245,8 @@ result_t test_mm_mul_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2] * _b[2];
     float dw = _a[3] * _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_mul_ps(a, b);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -2261,8 +2261,8 @@ result_t test_mm_mul_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_mul_ss(a, b);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -2277,8 +2277,8 @@ result_t test_mm_mulhi_pu16(const SSE2NEONTestImpl &impl, uint32_t iter)
         d[i] = (uint16_t)(m >> 16);
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_mulhi_pu16(a, b);
     return validateUInt16(c, d[0], d[1], d[2], d[3]);
 }
@@ -2287,8 +2287,8 @@ result_t test_mm_or_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_or_ps(a, b);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
@@ -2368,8 +2368,8 @@ result_t test_m_psadbw(const SSE2NEONTestImpl &impl, uint32_t iter)
         d += abs(_a[i] - _b[i]);
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _m_psadbw(a, b);
     return validateUInt16(c, d, 0, 0, 0);
 }
@@ -2387,7 +2387,7 @@ result_t test_mm_rcp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = 1.0f / _a[2];
     float dw = 1.0f / _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ps(a);
     return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
 }
@@ -2401,7 +2401,7 @@ result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ss(a);
     return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
 }
@@ -2415,7 +2415,7 @@ result_t test_mm_rsqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = 1 / sqrt(_a[2]);
     float f3 = 1 / sqrt(_a[3]);
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ps(a);
 
     // Here, we ensure `_mm_rsqrt_ps()`'s error is under 1% compares to the C
@@ -2432,7 +2432,7 @@ result_t test_mm_rsqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2];
     float f3 = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ss(a);
 
     // Here, we ensure `_mm_rsqrt_ps()`'s error is under 1% compares to the C
@@ -2449,8 +2449,8 @@ result_t test_mm_sad_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
         d += abs(_a[i] - _b[i]);
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_sad_pu8(a, b);
     return validateUInt16(c, d, 0, 0, 0);
 }
@@ -2479,7 +2479,7 @@ result_t test_mm_set_rounding_mode(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     result_t res_toward_zero, res_to_neg_inf, res_to_pos_inf, res_nearest;
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 b, c;
 
     _MM_SET_ROUNDING_MODE(_MM_ROUND_TOWARD_ZERO);
@@ -2557,7 +2557,7 @@ result_t test_mm_shuffle_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
     const int32_t imm = 73;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
 
     int16_t d0 = _a[imm & 0x3];
     int16_t d1 = _a[(imm >> 2) & 0x3];
@@ -2577,8 +2577,8 @@ result_t test_mm_shuffle_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
     result_t isValid = TEST_SUCCESS;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     // Test many permutations of the shuffle operation, including all
     // permutations which have an optimized/customized implementation
     __m128 ret;
@@ -2647,7 +2647,7 @@ result_t test_mm_sqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = sqrt(_a[2]);
     float f3 = sqrt(_a[3]);
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ps(a);
 
     // Here, we ensure `_mm_sqrt_ps()`'s error is under 1% compares to the C
@@ -2664,7 +2664,7 @@ result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2];
     float f3 = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ss(a);
 
     // Here, we ensure `_mm_sqrt_ps()`'s error is under 1% compares to the C
@@ -2693,7 +2693,7 @@ result_t test_mm_store_ps1(const SSE2NEONTestImpl &impl, uint32_t iter)
     float *p = impl.mTestFloatPointer1;
     float d[4];
 
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     _mm_store_ps1(d, a);
 
     ASSERT_RETURN(d[0] == *p);
@@ -2719,7 +2719,7 @@ result_t test_mm_store1_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float *p = impl.mTestFloatPointer1;
     float d[4];
 
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     _mm_store1_ps(d, a);
 
     ASSERT_RETURN(d[0] == *p);
@@ -2764,7 +2764,7 @@ result_t test_mm_storer_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float *p = impl.mTestFloatPointer1;
     float d[4];
 
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     _mm_storer_ps(d, a);
 
     ASSERT_RETURN(d[0] == p[3]);
@@ -2794,7 +2794,7 @@ result_t test_mm_storeu_si16(const SSE2NEONTestImpl &impl, uint32_t iter)
 #else
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     __m128i b;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     _mm_storeu_si16(&b, a);
     int16_t *_b = (int16_t *) &b;
     int16_t *_c = (int16_t *) &a;
@@ -2807,7 +2807,7 @@ result_t test_mm_storeu_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     __m128i b;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     _mm_storeu_si64(&b, a);
     int64_t *_b = (int64_t *) &b;
     int64_t *_c = (int64_t *) &a;
@@ -2817,7 +2817,7 @@ result_t test_mm_storeu_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_stream_pi(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestIntPointer1;
-    __m64 a = do_mm_load_m64(_a);
+    __m64 a = load_m64(_a);
     __m64 p;
 
     _mm_stream_pi(&p, a);
@@ -2827,7 +2827,7 @@ result_t test_mm_stream_pi(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_stream_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     float p[4];
 
     _mm_stream_ps(p, a);
@@ -2847,8 +2847,8 @@ result_t test_mm_sub_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2] - _b[2];
     float dw = _a[3] - _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_sub_ps(a, b);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -2862,8 +2862,8 @@ result_t test_mm_sub_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = _a[2];
     float dw = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_sub_ss(a, b);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -2954,8 +2954,8 @@ result_t test_mm_xor_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = _a[2] ^ _b[2];
     int32_t d3 = _a[3] ^ _b[3];
 
-    __m128 a = do_mm_load_ps((const float *) _a);
-    __m128 b = do_mm_load_ps((const float *) _b);
+    __m128 a = load_m128((const float *) _a);
+    __m128 b = load_m128((const float *) _b);
     __m128 c = _mm_xor_ps(a, b);
 
     return validateFloat(c, *((float *) &d0), *((float *) &d1),
@@ -2977,8 +2977,8 @@ result_t test_mm_add_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] + _b[6];
     int16_t d7 = _a[7] + _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_add_epi16(a, b);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -2993,8 +2993,8 @@ result_t test_mm_add_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t dz = _a[2] + _b[2];
     int32_t dw = _a[3] + _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_add_epi32(a, b);
     return validateInt32(c, dx, dy, dz, dw);
 }
@@ -3007,8 +3007,8 @@ result_t test_mm_add_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] + _b[0];
     int64_t d1 = _a[1] + _b[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_add_epi64(a, b);
 
     return validateInt64(c, d0, d1);
@@ -3035,8 +3035,8 @@ result_t test_mm_add_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = _a[14] + _b[14];
     int8_t d15 = _a[15] + _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_add_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -3049,8 +3049,8 @@ result_t test_mm_add_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] + _b[0];
     double d1 = _a[1] + _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_add_pd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -3062,8 +3062,8 @@ result_t test_mm_add_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] + _b[0];
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_add_sd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -3075,8 +3075,8 @@ result_t test_mm_add_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int64_t d0 = _a[0] + _b[0];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_add_si64(a, b);
 
     return validateInt64(c, d0);
@@ -3127,8 +3127,8 @@ result_t test_mm_adds_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (d7 < -32768)
         d7 = -32768;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
 
     __m128i c = _mm_adds_epi16(a, b);
     return validateInt16(c, (int16_t) d0, (int16_t) d1, (int16_t) d2,
@@ -3150,8 +3150,8 @@ result_t test_mm_adds_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i] = -128;
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_adds_epi8(a, b);
 
     return validateInt8(
@@ -3184,8 +3184,8 @@ result_t test_mm_adds_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d7 =
         (uint32_t) _a[7] + (uint32_t) _b[7] > max ? max : _a[7] + _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_adds_epu16(a, b);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -3244,8 +3244,8 @@ result_t test_mm_adds_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (d15 < (uint8_t) _a[15])
         d15 = 255;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_adds_epu8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -3259,8 +3259,8 @@ result_t test_mm_and_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] & _b[0];
     int64_t d1 = _a[1] & _b[1];
 
-    __m128d a = do_mm_load_pd((const double *) _a);
-    __m128d b = do_mm_load_pd((const double *) _b);
+    __m128d a = load_m128d((const double *) _a);
+    __m128d b = load_m128d((const double *) _b);
     __m128d c = _mm_and_pd(a, b);
 
     return validateDouble(c, *((double *) &d0), *((double *) &d1));
@@ -3270,8 +3270,8 @@ result_t test_mm_and_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
     const int32_t *_b = impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128 fc = _mm_and_ps(*(const __m128 *) &a, *(const __m128 *) &b);
     __m128i c = *(const __m128i *) &fc;
     // now for the assertion...
@@ -3294,8 +3294,8 @@ result_t test_mm_andnot_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_andnot_pd(a, b);
 
     // Take AND operation a complement of 'a' and 'b'. Bitwise operations are
@@ -3313,8 +3313,8 @@ result_t test_mm_andnot_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_a = impl.mTestIntPointer1;
     const int32_t *_b = impl.mTestIntPointer2;
     result_t r = TEST_SUCCESS;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128 fc = _mm_andnot_ps(*(const __m128 *) &a, *(const __m128 *) &b);
     __m128i c = *(const __m128i *) &fc;
     // now for the assertion...
@@ -3344,8 +3344,8 @@ result_t test_mm_avg_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d5 = ((uint16_t) _a[5] + (uint16_t) _b[5] + 1) >> 1;
     uint16_t d6 = ((uint16_t) _a[6] + (uint16_t) _b[6] + 1) >> 1;
     uint16_t d7 = ((uint16_t) _a[7] + (uint16_t) _b[7] + 1) >> 1;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_avg_epu16(a, b);
     return validateUInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -3370,8 +3370,8 @@ result_t test_mm_avg_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint8_t d13 = ((uint8_t) _a[13] + (uint8_t) _b[13] + 1) >> 1;
     uint8_t d14 = ((uint8_t) _a[14] + (uint8_t) _b[14] + 1) >> 1;
     uint8_t d15 = ((uint8_t) _a[15] + (uint8_t) _b[15] + 1) >> 1;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_avg_epu8(a, b);
     return validateUInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                          d12, d13, d14, d15);
@@ -3390,8 +3390,8 @@ result_t test_mm_bsrli_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_castpd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    const __m128d a = do_mm_load_pd((const double *) _a);
-    const __m128 _c = do_mm_load_ps(_a);
+    const __m128d a = load_m128d((const double *) _a);
+    const __m128 _c = load_m128(_a);
 
     __m128 r = _mm_castpd_ps(a);
 
@@ -3401,7 +3401,7 @@ result_t test_mm_castpd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_castpd_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    const __m128d a = do_mm_load_pd((const double *) _a);
+    const __m128d a = load_m128d((const double *) _a);
     const __m128i *_c = (const __m128i *) _a;
 
     __m128i r = _mm_castpd_si128(a);
@@ -3412,7 +3412,7 @@ result_t test_mm_castpd_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_castps_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    const __m128 a = do_mm_load_ps(_a);
+    const __m128 a = load_m128(_a);
     const __m128d *_c = (const __m128d *) _a;
 
     __m128d r = _mm_castps_pd(a);
@@ -3426,7 +3426,7 @@ result_t test_mm_castps_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     const __m128i *_c = (const __m128i *) _a;
 
-    const __m128 a = do_mm_load_ps(_a);
+    const __m128 a = load_m128(_a);
     __m128i r = _mm_castps_si128(a);
 
     return validate128(r, *_c);
@@ -3438,7 +3438,7 @@ result_t test_mm_castsi128_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     const __m128d *_c = (const __m128d *) _a;
 
-    const __m128i a = do_mm_load_ps(_a);
+    const __m128i a = load_m128i(_a);
     __m128d r = _mm_castsi128_pd(a);
 
     return validate128(r, *_c);
@@ -3450,7 +3450,7 @@ result_t test_mm_castsi128_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     const __m128 *_c = (const __m128 *) _a;
 
-    const __m128i a = do_mm_load_ps(_a);
+    const __m128i a = load_m128i(_a);
     __m128 r = _mm_castsi128_ps(a);
 
     return validate128(r, *_c);
@@ -3474,8 +3474,8 @@ result_t test_mm_cmpeq_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = (_a[6] == _b[6]) ? ~UINT16_C(0) : 0x0;
     int16_t d7 = (_a[7] == _b[7]) ? ~UINT16_C(0) : 0x0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmpeq_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -3490,8 +3490,8 @@ result_t test_mm_cmpeq_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = (_a[2] == _b[2]) ? ~UINT32_C(0) : 0x0;
     int32_t d3 = (_a[3] == _b[3]) ? ~UINT32_C(0) : 0x0;
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_cmpeq_epi32(a, b);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -3518,8 +3518,8 @@ result_t test_mm_cmpeq_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = (_a[14] == _b[14]) ? ~UINT8_C(0) : 0x00;
     int8_t d15 = (_a[15] == _b[15]) ? ~UINT8_C(0) : 0x00;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmpeq_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -3532,8 +3532,8 @@ result_t test_mm_cmpeq_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] == _b[0]) ? 0xffffffffffffffff : 0;
     uint64_t d1 = (_a[1] == _b[1]) ? 0xffffffffffffffff : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpeq_pd(a, b);
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
 }
@@ -3545,8 +3545,8 @@ result_t test_mm_cmpeq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const uint64_t d0 = (_a[0] == _b[0]) ? ~UINT64_C(0) : 0;
     const uint64_t d1 = ((const uint64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpeq_sd(a, b);
 
     return validateDouble(c, *(const double *) &d0, *(const double *) &d1);
@@ -3559,8 +3559,8 @@ result_t test_mm_cmpge_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = (_a[1] >= _b[1]) ? ~UINT64_C(0) : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpge_pd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3573,8 +3573,8 @@ result_t test_mm_cmpge_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = ((uint64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpge_sd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3593,8 +3593,8 @@ result_t test_mm_cmpgt_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d6 = _a[6] > _b[6] ? ~UINT16_C(0) : 0;
     uint16_t d7 = _a[7] > _b[7] ? ~UINT16_C(0) : 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmpgt_epi16(a, b);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -3604,8 +3604,8 @@ result_t test_mm_cmpgt_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
     const int32_t *_b = impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
 
     int32_t result[4];
 
@@ -3639,8 +3639,8 @@ result_t test_mm_cmpgt_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = (_a[14] > _b[14]) ? ~UINT8_C(0) : 0x00;
     int8_t d15 = (_a[15] > _b[15]) ? ~UINT8_C(0) : 0x00;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmpgt_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -3653,8 +3653,8 @@ result_t test_mm_cmpgt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = (_a[1] > _b[1]) ? ~UINT64_C(0) : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpgt_pd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3667,8 +3667,8 @@ result_t test_mm_cmpgt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = ((uint64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpgt_sd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3681,8 +3681,8 @@ result_t test_mm_cmple_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = (_a[1] <= _b[1]) ? ~UINT64_C(0) : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmple_pd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3695,8 +3695,8 @@ result_t test_mm_cmple_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = ((uint64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmple_sd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3715,8 +3715,8 @@ result_t test_mm_cmplt_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d6 = _a[6] < _b[6] ? ~UINT16_C(0) : 0;
     uint16_t d7 = _a[7] < _b[7] ? ~UINT16_C(0) : 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmplt_epi16(a, b);
 
     return validateUInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -3726,8 +3726,8 @@ result_t test_mm_cmplt_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
     const int32_t *_b = impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
 
     int32_t result[4];
     result[0] = _a[0] < _b[0] ? -1 : 0;
@@ -3760,8 +3760,8 @@ result_t test_mm_cmplt_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = (_a[14] < _b[14]) ? ~UINT8_C(0) : 0x00;
     int8_t d15 = (_a[15] < _b[15]) ? ~UINT8_C(0) : 0x00;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmplt_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -3775,8 +3775,8 @@ result_t test_mm_cmplt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t f0 = (_a[0] < _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
     int64_t f1 = (_a[1] < _b[1]) ? ~UINT64_C(0) : UINT64_C(0);
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmplt_pd(a, b);
 
     return validateDouble(c, *(double *) &f0, *(double *) &f1);
@@ -3789,8 +3789,8 @@ result_t test_mm_cmplt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint64_t d0 = (_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
     uint64_t d1 = ((uint64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmplt_sd(a, b);
 
     return validateDouble(c, *(double *) &d0, *(double *) &d1);
@@ -3804,8 +3804,8 @@ result_t test_mm_cmpneq_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t f0 = (_a[0] != _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
     int64_t f1 = (_a[1] != _b[1]) ? ~UINT64_C(0) : UINT64_C(0);
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpneq_pd(a, b);
 
     return validateDouble(c, *(double *) &f0, *(double *) &f1);
@@ -3819,8 +3819,8 @@ result_t test_mm_cmpneq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t f0 = (_a[0] != _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
     int64_t f1 = ((int64_t *) _a)[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpneq_sd(a, b);
 
     return validateDouble(c, *(double *) &f0, *(double *) &f1);
@@ -3936,8 +3936,8 @@ result_t test_mm_comieq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] == _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comieq_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -3950,8 +3950,8 @@ result_t test_mm_comige_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] >= _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comige_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -3964,8 +3964,8 @@ result_t test_mm_comigt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] > _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comigt_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -3978,8 +3978,8 @@ result_t test_mm_comile_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] <= _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comile_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -3992,8 +3992,8 @@ result_t test_mm_comilt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] < _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comilt_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -4006,8 +4006,8 @@ result_t test_mm_comineq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_b = (const double *) impl.mTestFloatPointer2;
     int32_t _c = (_a[0] != _b[0]) ? 1 : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     int32_t c = _mm_comineq_sd(a, b);
 
     ASSERT_RETURN(c == _c);
@@ -4017,7 +4017,7 @@ result_t test_mm_comineq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_cvtepi32_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     double trun[2] = {(double) _a[0], (double) _a[1]};
 
     __m128d ret = _mm_cvtepi32_pd(a);
@@ -4027,7 +4027,7 @@ result_t test_mm_cvtepi32_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_cvtepi32_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     float trun[4];
     for (uint32_t i = 0; i < 4; i++) {
         trun[i] = (float) _a[i];
@@ -4065,7 +4065,7 @@ result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128i ret = _mm_cvtpd_epi32(a);
 
     return validateInt32(ret, d[0], d[1], 0, 0);
@@ -4099,7 +4099,7 @@ result_t test_mm_cvtpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m64 ret = _mm_cvtpd_pi32(a);
 
     return validateInt32(ret, d[0], d[1]);
@@ -4110,7 +4110,7 @@ result_t test_mm_cvtpd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     float f0 = (float) _a[0];
     float f1 = (float) _a[1];
-    const __m128d a = do_mm_load_pd(_a);
+    const __m128d a = load_m128d(_a);
 
     __m128 r = _mm_cvtpd_ps(a);
 
@@ -4120,7 +4120,7 @@ result_t test_mm_cvtpd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_cvtpi32_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
 
     double trun[2] = {(double) _a[0], (double) _a[1]};
 
@@ -4132,7 +4132,7 @@ result_t test_mm_cvtpi32_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_cvtps_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int32_t d[4];
     switch (iter & 0x3) {
     case 0:
@@ -4170,7 +4170,7 @@ result_t test_mm_cvtps_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     double d0 = (double) _a[0];
     double d1 = (double) _a[1];
-    const __m128 a = do_mm_load_ps(_a);
+    const __m128 a = load_m128(_a);
 
     __m128d r = _mm_cvtps_pd(a);
 
@@ -4213,7 +4213,7 @@ result_t test_mm_cvtsd_si32(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     int32_t ret = _mm_cvtsd_si32(a);
 
     return ret == d ? TEST_SUCCESS : TEST_FAIL;
@@ -4243,7 +4243,7 @@ result_t test_mm_cvtsd_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
         break;
     }
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     int64_t ret = _mm_cvtsd_si64(a);
 
     return ret == d ? TEST_SUCCESS : TEST_FAIL;
@@ -4264,8 +4264,8 @@ result_t test_mm_cvtsd_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2];
     float f3 = _a[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128 a = load_m128(_a);
+    __m128d b = load_m128d(_b);
     __m128 c = _mm_cvtsd_ss(a, b);
 
     return validateFloat(c, f0, f1, f2, f3);
@@ -4277,7 +4277,7 @@ result_t test_mm_cvtsi128_si32(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int32_t d = _a[0];
 
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     int c = _mm_cvtsi128_si32(a);
 
     return d == c ? TEST_SUCCESS : TEST_FAIL;
@@ -4289,7 +4289,7 @@ result_t test_mm_cvtsi128_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int64_t d = _a[0];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     int64_t c = _mm_cvtsi128_si64(a);
 
     return d == c ? TEST_SUCCESS : TEST_FAIL;
@@ -4305,7 +4305,7 @@ result_t test_mm_cvtsi32_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const int32_t b = (const int32_t) impl.mTestInts[iter];
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d c = _mm_cvtsi32_sd(a, b);
 
     return validateDouble(c, b, _a[1]);
@@ -4327,7 +4327,7 @@ result_t test_mm_cvtsi64_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const int64_t b = (const int64_t) impl.mTestInts[iter];
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d c = _mm_cvtsi64_sd(a, b);
 
     return validateDouble(c, b, _a[1]);
@@ -4361,8 +4361,8 @@ result_t test_mm_cvtss_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = double(_b[0]);
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128d a = load_m128d(_a);
+    __m128 b = load_m128(_b);
     __m128d c = _mm_cvtss_sd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -4371,7 +4371,7 @@ result_t test_mm_cvttpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     int32_t d0 = (int32_t)(_a[0]);
     int32_t d1 = (int32_t)(_a[1]);
 
@@ -4383,7 +4383,7 @@ result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     int32_t d0 = (int32_t)(_a[0]);
     int32_t d1 = (int32_t)(_a[1]);
 
@@ -4394,7 +4394,7 @@ result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_cvttps_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     int32_t trun[4];
     for (uint32_t i = 0; i < 4; i++) {
         trun[i] = (int32_t) _a[i];
@@ -4450,8 +4450,8 @@ result_t test_mm_div_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (_b[1] != 0.0)
         d1 = _a[1] / _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_div_pd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -4464,8 +4464,8 @@ result_t test_mm_div_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] / _b[0];
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
 
     __m128d c = _mm_div_sd(a, b);
 
@@ -4476,7 +4476,7 @@ result_t test_mm_extract_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     uint16_t *_a = (uint16_t *) impl.mTestIntPointer1;
     const int idx = iter & 0x7;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     int c;
     switch (idx) {
     case 0:
@@ -4521,7 +4521,7 @@ result_t test_mm_insert_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
     d[imm8] = insert;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_insert_epi16(a, insert, imm8);
     return validateInt16(b, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 }
@@ -4575,7 +4575,7 @@ result_t test_mm_loadh_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *addr = (const double *) impl.mTestFloatPointer2;
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d ret = _mm_loadh_pd(a, addr);
 
     return validateDouble(ret, _a[0], addr[0]);
@@ -4595,7 +4595,7 @@ result_t test_mm_loadl_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *addr = (const double *) impl.mTestFloatPointer2;
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d ret = _mm_loadl_pd(a, addr);
 
     return validateDouble(ret, addr[0], _a[1]);
@@ -4658,8 +4658,8 @@ result_t test_mm_madd_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t e2 = d4 + d5;
     int32_t e3 = d6 + d7;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_madd_epi16(a, b);
     return validateInt32(c, e0, e1, e2, e3);
 }
@@ -4670,8 +4670,8 @@ result_t test_mm_maskmoveu_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const uint8_t *_mask = (const uint8_t *) impl.mTestIntPointer2;
     char mem_addr[16];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i mask = do_mm_load_ps((const int32_t *) _mask);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i mask = load_m128i((const int32_t *) _mask);
     _mm_maskmoveu_si128(a, mask, mem_addr);
 
     for (int i = 0; i < 16; i++) {
@@ -4696,8 +4696,8 @@ result_t test_mm_max_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] > _b[6] ? _a[6] : _b[6];
     int16_t d7 = _a[7] > _b[7] ? _a[7] : _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
 
     __m128i c = _mm_max_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -4740,8 +4740,8 @@ result_t test_mm_max_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint8_t d15 = ((uint8_t) _a[15] > (uint8_t) _b[15]) ? ((uint8_t) _a[15])
                                                         : ((uint8_t) _b[15]);
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_max_epu8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -4755,8 +4755,8 @@ result_t test_mm_max_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = _a[0] > _b[0] ? _a[0] : _b[0];
     double f1 = _a[1] > _b[1] ? _a[1] : _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_max_pd(a, b);
 
     return validateDouble(c, f0, f1);
@@ -4769,8 +4769,8 @@ result_t test_mm_max_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = fmax(_a[0], _b[0]);
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_max_sd(a, b);
 
     return validateDouble(c, d0, d1);
@@ -4794,8 +4794,8 @@ result_t test_mm_min_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] < _b[6] ? _a[6] : _b[6];
     int16_t d7 = _a[7] < _b[7] ? _a[7] : _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_min_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -4837,8 +4837,8 @@ result_t test_mm_min_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint8_t d15 = ((uint8_t) _a[15] < (uint8_t) _b[15]) ? (uint8_t) _a[15]
                                                         : (uint8_t) _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_min_epu8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -4851,8 +4851,8 @@ result_t test_mm_min_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = fmin(_a[0], _b[0]);
     double f1 = fmin(_a[1], _b[1]);
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
 
     __m128d c = _mm_min_pd(a, b);
     return validateDouble(c, f0, f1);
@@ -4865,8 +4865,8 @@ result_t test_mm_min_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = fmin(_a[0], _b[0]);
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_min_sd(a, b);
 
     return validateDouble(c, d0, d1);
@@ -4879,7 +4879,7 @@ result_t test_mm_move_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0];
     int64_t d1 = 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_move_epi64(a);
 
     return validateInt64(c, d0, d1);
@@ -4889,8 +4889,8 @@ result_t test_mm_move_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
 
     double result[2];
     result[0] = _b[0];
@@ -4903,7 +4903,7 @@ result_t test_mm_move_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_movemask_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
 
     const uint8_t *ip = (const uint8_t *) _a;
     int ret = 0;
@@ -4926,7 +4926,7 @@ result_t test_mm_movemask_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     _c |= ((*(const uint64_t *) _a) >> 63) & 0x1;
     _c |= (((*(const uint64_t *) (_a + 1)) >> 62) & 0x2);
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     int c = _mm_movemask_pd(a);
 
     ASSERT_RETURN((unsigned int) c == _c);
@@ -4939,7 +4939,7 @@ result_t test_mm_movepi64_pi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int64_t d0 = _a[0];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m64 c = _mm_movepi64_pi64(a);
 
     return validateInt64(c, d0);
@@ -4951,7 +4951,7 @@ result_t test_mm_movpi64_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int64_t d0 = _a[0];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m128i c = _mm_movpi64_epi64(a);
 
     return validateInt64(c, d0, 0);
@@ -4990,8 +4990,8 @@ result_t test_mm_mul_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double dx = _a[0] * _b[0];
     double dy = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_mul_sd(a, b);
     return validateDouble(c, dx, dy);
 }
@@ -5003,8 +5003,8 @@ result_t test_mm_mul_su32(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     uint64_t u = (uint64_t)(_a[0]) * (uint64_t)(_b[0]);
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 r = _mm_mul_su32(a, b);
 
     return validateUInt64(r, u);
@@ -5020,8 +5020,8 @@ result_t test_mm_mulhi_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         d[i] = (int16_t)(m >> 16);
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_mulhi_epi16(a, b);
     return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 }
@@ -5036,8 +5036,8 @@ result_t test_mm_mulhi_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
         d[i] = (uint16_t)(m >> 16);
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_mulhi_epu16(a, b);
     return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
 }
@@ -5055,8 +5055,8 @@ result_t test_mm_mullo_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] * _b[6];
     int16_t d7 = _a[7] * _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_mullo_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -5069,8 +5069,8 @@ result_t test_mm_or_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] | _b[0];
     int64_t d1 = _a[1] | _b[1];
 
-    __m128d a = do_mm_load_pd((const double *) _a);
-    __m128d b = do_mm_load_pd((const double *) _b);
+    __m128d a = load_m128d((const double *) _a);
+    __m128d b = load_m128d((const double *) _b);
     __m128d c = _mm_or_pd(a, b);
 
     return validateDouble(c, *((double *) &d0), *((double *) &d1));
@@ -5080,8 +5080,8 @@ result_t test_mm_or_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = impl.mTestIntPointer1;
     const int32_t *_b = impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128 fc = _mm_or_ps(*(const __m128 *) &a, *(const __m128 *) &b);
     __m128i c = *(const __m128i *) &fc;
     // now for the assertion...
@@ -5124,8 +5124,8 @@ result_t test_mm_packs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i + 8] = (int8_t) _b[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_packs_epi16(a, b);
 
     return validateInt8(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8],
@@ -5157,8 +5157,8 @@ result_t test_mm_packs_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i + 4] = (int16_t) _b[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_packs_epi32(a, b);
 
     return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -5189,8 +5189,8 @@ result_t test_mm_packus_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i + 8] = (uint8_t) _b[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_packus_epi16(a, b);
 
     return validateUInt8(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
@@ -5216,8 +5216,8 @@ result_t test_mm_sad_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
         d1 += abs(_a[i] - _b[i]);
     }
 
-    const __m128i a = do_mm_load_ps((const int32_t *) _a);
-    const __m128i b = do_mm_load_ps((const int32_t *) _b);
+    const __m128i a = load_m128i((const int32_t *) _a);
+    const __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sad_epu8(a, b);
     return validateUInt16(c, d0, 0, 0, 0, d1, 0, 0, 0);
 }
@@ -5444,7 +5444,7 @@ result_t test_mm_shuffle_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = _a[((imm >> 4) & 0x3)];
     int32_t d3 = _a[((imm >> 6) & 0x3)];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_shuffle_epi32(a, imm);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -5458,8 +5458,8 @@ result_t test_mm_shuffle_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[iter & 0x1];
     double d1 = _b[(iter & 0x2) >> 1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c;
     switch (iter & 0x3) {
     case 0:
@@ -5493,7 +5493,7 @@ result_t test_mm_shufflehi_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = ((const int64_t *) _a)[1] >> (((imm >> 4) & 0x3) * 16);
     int16_t d7 = ((const int64_t *) _a)[1] >> (((imm >> 6) & 0x3) * 16);
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_shufflehi_epi16(a, imm);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -5513,7 +5513,7 @@ result_t test_mm_shufflelo_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6];
     int16_t d7 = _a[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_shufflelo_epi16(a, imm);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -5523,7 +5523,7 @@ result_t test_mm_sll_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_sll_epi16(a, b);
     if (count < 0 || count > 15)
@@ -5544,7 +5544,7 @@ result_t test_mm_sll_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_sll_epi32(a, b);
     if (count < 0 || count > 31)
@@ -5561,7 +5561,7 @@ result_t test_mm_sll_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_sll_epi64(a, b);
     if (count < 0 || count > 63)
@@ -5586,7 +5586,7 @@ result_t test_mm_slli_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] << count;
     int16_t d7 = _a[7] << count;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_slli_epi16(a, count);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -5611,7 +5611,7 @@ result_t test_mm_slli_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = (count > 31) ? 0 : _a[2] << count;
     int32_t d3 = (count > 31) ? 0 : _a[3] << count;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_slli_epi32(a, count);
     return validateInt32(c, d0, d1, d2, d3);
 }
@@ -5634,7 +5634,7 @@ result_t test_mm_slli_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = (count > 63) ? 0 : _a[0] << count;
     int64_t d1 = (count > 63) ? 0 : _a[1] << count;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_slli_epi64(a, count);
     return validateInt64(c, d0, d1);
 }
@@ -5654,7 +5654,7 @@ result_t test_mm_slli_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i] = ((const int8_t *) _a)[i - count];
     }
 
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     __m128i ret = _mm_slli_si128(a, 5);
 
     return validateInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
@@ -5668,7 +5668,7 @@ result_t test_mm_sqrt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = sqrt(_a[0]);
     double f1 = sqrt(_a[1]);
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d c = _mm_sqrt_pd(a);
 
     return validateDouble(c, f0, f1);
@@ -5682,8 +5682,8 @@ result_t test_mm_sqrt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = sqrt(_b[0]);
     double f1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_sqrt_sd(a, b);
 
     return validateDouble(c, f0, f1);
@@ -5783,7 +5783,7 @@ result_t test_mm_srl_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_srl_epi16(a, b);
     if (count < 0 || count > 15)
@@ -5804,7 +5804,7 @@ result_t test_mm_srl_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_srl_epi32(a, b);
     if (count < 0 || count > 31)
@@ -5821,7 +5821,7 @@ result_t test_mm_srl_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestIntPointer1;
     const int64_t count = (int64_t) iter;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_set1_epi64x(count);
     __m128i c = _mm_srl_epi64(a, b);
     if (count < 0 || count > 63)
@@ -5846,7 +5846,7 @@ result_t test_mm_srli_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = count & (~15) ? 0 : (uint16_t)(_a[6]) >> count;
     int16_t d7 = count & (~15) ? 0 : (uint16_t)(_a[7]) >> count;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_srli_epi16(a, count);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -5862,7 +5862,7 @@ result_t test_mm_srli_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = count & (~31) ? 0 : (uint32_t)(_a[2]) >> count;
     int32_t d3 = count & (~31) ? 0 : (uint32_t)(_a[3]) >> count;
 
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     __m128i c = _mm_srli_epi32(a, count);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -5876,7 +5876,7 @@ result_t test_mm_srli_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = count & (~63) ? 0 : (uint64_t)(_a[0]) >> count;
     int64_t d1 = count & (~63) ? 0 : (uint64_t)(_a[1]) >> count;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_srli_epi64(a, count);
 
     return validateInt64(c, d0, d1);
@@ -5897,7 +5897,7 @@ result_t test_mm_srli_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i] = _a[i + count];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_srli_si128(a, 5);
 
     return validateInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
@@ -5923,7 +5923,7 @@ result_t test_mm_store_pd1(const SSE2NEONTestImpl &impl, uint32_t iter)
     double _a[2] = {(double) impl.mTestFloats[iter],
                     (double) impl.mTestFloats[iter + 1]};
 
-    __m128d a = do_mm_load_pd((const double *) _a);
+    __m128d a = load_m128d((const double *) _a);
     _mm_store_pd1(p, a);
     ASSERT_RETURN(p[0] == impl.mTestFloats[iter]);
     ASSERT_RETURN(p[1] == impl.mTestFloats[iter]);
@@ -5936,7 +5936,7 @@ result_t test_mm_store_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double _a[2] = {(double) impl.mTestFloats[iter],
                     (double) impl.mTestFloats[iter + 1]};
 
-    __m128d a = do_mm_load_pd((const double *) _a);
+    __m128d a = load_m128d((const double *) _a);
     _mm_store_sd(p, a);
     ASSERT_RETURN(p[0] == impl.mTestFloats[iter]);
     return TEST_SUCCESS;
@@ -5947,7 +5947,7 @@ result_t test_mm_store_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     int32_t p[4];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     _mm_store_si128((__m128i *) p, a);
 
     return validateInt32(a, p[0], p[1], p[2], p[3]);
@@ -5963,7 +5963,7 @@ result_t test_mm_storeh_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double *p = (double *) impl.mTestFloatPointer1;
     double mem;
 
-    __m128d a = do_mm_load_pd(p);
+    __m128d a = load_m128d(p);
     _mm_storeh_pd(&mem, a);
 
     ASSERT_RETURN(mem == p[1]);
@@ -5975,7 +5975,7 @@ result_t test_mm_storel_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t *p = (int64_t *) impl.mTestIntPointer1;
     __m128i mem;
 
-    __m128i a = do_mm_load_ps((const int32_t *) p);
+    __m128i a = load_m128i((const int32_t *) p);
     _mm_storel_epi64(&mem, a);
 
     ASSERT_RETURN(mem[0] == p[0]);
@@ -5987,7 +5987,7 @@ result_t test_mm_storel_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double *p = (double *) impl.mTestFloatPointer1;
     double mem;
 
-    __m128d a = do_mm_load_pd(p);
+    __m128d a = load_m128d(p);
     _mm_storel_pd(&mem, a);
 
     ASSERT_RETURN(mem == p[0]);
@@ -5999,10 +5999,10 @@ result_t test_mm_storer_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double *p = (double *) impl.mTestFloatPointer1;
     double mem[2];
 
-    __m128d a = do_mm_load_pd(p);
+    __m128d a = load_m128d(p);
     _mm_storer_pd(mem, a);
 
-    __m128d res = do_mm_load_pd(mem);
+    __m128d res = load_m128d(mem);
     return validateDouble(res, p[1], p[0]);
 }
 
@@ -6023,7 +6023,7 @@ result_t test_mm_storeu_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     __m128i b;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     _mm_storeu_si128(&b, a);
     int32_t *_b = (int32_t *) &b;
     return validateInt32(a, _b[0], _b[1], _b[2], _b[3]);
@@ -6039,7 +6039,7 @@ result_t test_mm_storeu_si32(const SSE2NEONTestImpl &impl, uint32_t iter)
 #else
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     __m128i b;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     _mm_storeu_si32(&b, a);
     int32_t *_b = (int32_t *) &b;
     return validateInt32(b, _a[0], _b[1], _b[2], _b[3]);
@@ -6051,7 +6051,7 @@ result_t test_mm_stream_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     double p[2];
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     _mm_stream_pd(p, a);
 
     return validateDouble(a, p[0], p[1]);
@@ -6062,7 +6062,7 @@ result_t test_mm_stream_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     int32_t p[4];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     _mm_stream_si128((__m128i *) p, a);
 
     return validateInt32(a, p[0], p[1], p[2], p[3]);
@@ -6097,8 +6097,8 @@ result_t test_mm_sub_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _a[6] - _b[6];
     int16_t d7 = _a[7] - _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sub_epi16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -6112,8 +6112,8 @@ result_t test_mm_sub_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t dz = _a[2] - _b[2];
     int32_t dw = _a[3] - _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_sub_epi32(a, b);
     return validateInt32(c, dx, dy, dz, dw);
 }
@@ -6125,8 +6125,8 @@ result_t test_mm_sub_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] - _b[0];
     int64_t d1 = _a[1] - _b[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sub_epi64(a, b);
     return validateInt64(c, d0, d1);
 }
@@ -6152,8 +6152,8 @@ result_t test_mm_sub_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = _a[14] - _b[14];
     int8_t d15 = _a[15] - _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sub_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -6166,8 +6166,8 @@ result_t test_mm_sub_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] - _b[0];
     double d1 = _a[1] - _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_sub_pd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -6179,8 +6179,8 @@ result_t test_mm_sub_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] - _b[0];
     double d1 = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_sub_sd(a, b);
     return validateDouble(c, d0, d1);
 }
@@ -6192,8 +6192,8 @@ result_t test_mm_sub_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     int64_t d = _a[0] - _b[0];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_sub_si64(a, b);
 
     return validateInt64(c, d);
@@ -6217,8 +6217,8 @@ result_t test_mm_subs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i] = (int16_t) res;
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_subs_epi16(a, b);
 
     return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -6242,8 +6242,8 @@ result_t test_mm_subs_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i] = (int8_t) res;
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_subs_epi8(a, b);
 
     return validateInt8(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8],
@@ -6279,8 +6279,8 @@ result_t test_mm_subs_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (d7 > (uint16_t) _a[7])
         d7 = 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
 
     __m128i c = _mm_subs_epu16(a, b);
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -6339,8 +6339,8 @@ result_t test_mm_subs_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
     if (d15 > (uint8_t) _a[15])
         d15 = 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_subs_epu8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
                         d12, d13, d14, d15);
@@ -6404,8 +6404,8 @@ result_t test_mm_unpackhi_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t i6 = _a[7];
     int16_t i7 = _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpackhi_epi16(a, b);
 
     return validateInt16(ret, i0, i1, i2, i3, i4, i5, i6, i7);
@@ -6421,8 +6421,8 @@ result_t test_mm_unpackhi_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = _a[3];
     int32_t i3 = _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i ret = _mm_unpackhi_epi32(a, b);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -6436,8 +6436,8 @@ result_t test_mm_unpackhi_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = _a[1];
     int64_t i1 = _b[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpackhi_epi64(a, b);
 
     return validateInt64(ret, i0, i1);
@@ -6465,8 +6465,8 @@ result_t test_mm_unpackhi_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t i14 = _a[15];
     int8_t i15 = _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpackhi_epi8(a, b);
 
     return validateInt8(ret, i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11,
@@ -6478,8 +6478,8 @@ result_t test_mm_unpackhi_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d ret = _mm_unpackhi_pd(a, b);
 
     return validateDouble(ret, _a[1], _b[1]);
@@ -6499,8 +6499,8 @@ result_t test_mm_unpacklo_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t i6 = _a[3];
     int16_t i7 = _b[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpacklo_epi16(a, b);
 
     return validateInt16(ret, i0, i1, i2, i3, i4, i5, i6, i7);
@@ -6516,8 +6516,8 @@ result_t test_mm_unpacklo_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = _a[1];
     int32_t i3 = _b[1];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i ret = _mm_unpacklo_epi32(a, b);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -6531,8 +6531,8 @@ result_t test_mm_unpacklo_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = _a[0];
     int64_t i1 = _b[0];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpacklo_epi64(a, b);
 
     return validateInt64(ret, i0, i1);
@@ -6560,8 +6560,8 @@ result_t test_mm_unpacklo_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t i14 = _a[7];
     int8_t i15 = _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_unpacklo_epi8(a, b);
 
     return validateInt8(ret, i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11,
@@ -6573,8 +6573,8 @@ result_t test_mm_unpacklo_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d ret = _mm_unpacklo_pd(a, b);
 
     return validateDouble(ret, _a[0], _b[0]);
@@ -6588,8 +6588,8 @@ result_t test_mm_xor_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] ^ _b[0];
     int64_t d1 = _a[1] ^ _b[1];
 
-    __m128d a = do_mm_load_pd((const double *) _a);
-    __m128d b = do_mm_load_pd((const double *) _b);
+    __m128d a = load_m128d((const double *) _a);
+    __m128d b = load_m128d((const double *) _b);
     __m128d c = _mm_xor_pd(a, b);
 
     return validateDouble(c, *((double *) &d0), *((double *) &d1));
@@ -6603,8 +6603,8 @@ result_t test_mm_xor_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = _a[0] ^ _b[0];
     int64_t d1 = _a[1] ^ _b[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_xor_si128(a, b);
 
     return validateInt64(c, d0, d1);
@@ -6619,8 +6619,8 @@ result_t test_mm_addsub_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d0 = _a[0] - _b[0];
     double d1 = _a[1] + _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_addsub_pd(a, b);
 
     return validateDouble(c, d0, d1);
@@ -6638,8 +6638,8 @@ result_t test_mm_addsub_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _a[2] - _b[2];
     float f3 = _a[3] + _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_addsub_ps(a, b);
 
     return validateFloat(c, f0, f1, f2, f3);
@@ -6653,8 +6653,8 @@ result_t test_mm_hadd_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = _a[0] + _a[1];
     double f1 = _b[0] + _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_hadd_pd(a, b);
 
     return validateDouble(c, f0, f1);
@@ -6672,8 +6672,8 @@ result_t test_mm_hadd_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _b[0] + _b[1];
     float f3 = _b[2] + _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_hadd_ps(a, b);
 
     return validateFloat(c, f0, f1, f2, f3);
@@ -6687,8 +6687,8 @@ result_t test_mm_hsub_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double f0 = _a[0] - _a[1];
     double f1 = _b[0] - _b[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d c = _mm_hsub_pd(a, b);
 
     return validateDouble(c, f0, f1);
@@ -6706,8 +6706,8 @@ result_t test_mm_hsub_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f2 = _b[0] - _b[1];
     float f3 = _b[2] - _b[3];
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_hsub_ps(a, b);
 
     return validateFloat(c, f0, f1, f2, f3);
@@ -6730,7 +6730,7 @@ result_t test_mm_loaddup_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_movedup_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *p = (const double *) impl.mTestFloatPointer1;
-    __m128d a = do_mm_load_pd(p);
+    __m128d a = load_m128d(p);
     __m128d b = _mm_movedup_pd(a);
 
     return validateDouble(b, p[0], p[0]);
@@ -6739,14 +6739,14 @@ result_t test_mm_movedup_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_movehdup_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *p = impl.mTestFloatPointer1;
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     return validateFloat(_mm_movehdup_ps(a), p[1], p[1], p[3], p[3]);
 }
 
 result_t test_mm_moveldup_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *p = impl.mTestFloatPointer1;
-    __m128 a = do_mm_load_ps(p);
+    __m128 a = load_m128(p);
     return validateFloat(_mm_moveldup_ps(a), p[0], p[0], p[2], p[2]);
 }
 
@@ -6754,7 +6754,7 @@ result_t test_mm_moveldup_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_abs_epi16(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6772,7 +6772,7 @@ result_t test_mm_abs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     __m128i c = _mm_abs_epi32(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6786,7 +6786,7 @@ result_t test_mm_abs_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int8_t *_a = (const int8_t *) impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i c = _mm_abs_epi8(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6813,7 +6813,7 @@ result_t test_mm_abs_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m64 c = _mm_abs_pi16(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6827,7 +6827,7 @@ result_t test_mm_abs_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m64 c = _mm_abs_pi32(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6839,7 +6839,7 @@ result_t test_mm_abs_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_abs_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int8_t *_a = (const int8_t *) impl.mTestIntPointer1;
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
+    __m64 a = load_m64((const int64_t *) _a);
     __m64 c = _mm_abs_pi8(a);
 
     uint32_t d0 = (_a[0] < 0) ? -_a[0] : _a[0];
@@ -6879,8 +6879,8 @@ result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_alignr_epi8(a, b, shift);
 
     return validateUInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
@@ -6913,8 +6913,8 @@ result_t test_mm_alignr_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_alignr_pi8(a, b, shift);
 
     return validateUInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -6933,8 +6933,8 @@ result_t test_mm_hadd_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d5 = _b[2] + _b[3];
     int16_t d6 = _b[4] + _b[5];
     int16_t d7 = _b[6] + _b[7];
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_hadd_epi16(a, b);
     return validateInt16(ret, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -6947,8 +6947,8 @@ result_t test_mm_hadd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d1 = _a[2] + _a[3];
     int32_t d2 = _b[0] + _b[1];
     int32_t d3 = _b[2] + _b[3];
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_hadd_epi32(a, b);
     return validateInt32(ret, d0, d1, d2, d3);
 }
@@ -6961,8 +6961,8 @@ result_t test_mm_hadd_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d1 = _a[2] + _a[3];
     int16_t d2 = _b[0] + _b[1];
     int16_t d3 = _b[2] + _b[3];
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_hadd_pi16(a, b);
     return validateInt16(ret, d0, d1, d2, d3);
 }
@@ -6973,8 +6973,8 @@ result_t test_mm_hadd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_b = (const int32_t *) impl.mTestIntPointer2;
     int32_t d0 = _a[0] + _a[1];
     int32_t d1 = _b[0] + _b[1];
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_hadd_pi32(a, b);
     return validateInt32(ret, d0, d1);
 }
@@ -7003,8 +7003,8 @@ result_t test_mm_hadds_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d16[i] = (int16_t) d32[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_hadds_epi16(a, b);
 
     return validateInt16(c, d16[0], d16[1], d16[2], d16[3], d16[4], d16[5],
@@ -7031,8 +7031,8 @@ result_t test_mm_hadds_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d16[i] = (int16_t) d32[i];
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_hadds_pi16(a, b);
 
     return validateInt16(c, d16[0], d16[1], d16[2], d16[3]);
@@ -7052,8 +7052,8 @@ result_t test_mm_hsub_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d6 = _b[4] - _b[5];
     int16_t d7 = _b[6] - _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_hsub_epi16(a, b);
 
     return validateInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -7069,8 +7069,8 @@ result_t test_mm_hsub_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = _b[0] - _b[1];
     int32_t d3 = _b[2] - _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_hsub_epi32(a, b);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -7085,8 +7085,8 @@ result_t test_mm_hsub_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t d1 = _a[2] - _a[3];
     int16_t d2 = _b[0] - _b[1];
     int16_t d3 = _b[2] - _b[3];
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_hsub_pi16(a, b);
 
     return validateInt16(c, d0, d1, d2, d3);
@@ -7100,8 +7100,8 @@ result_t test_mm_hsub_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d0 = _a[0] - _a[1];
     int32_t d1 = _b[0] - _b[1];
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_hsub_pi32(a, b);
 
     return validateInt32(c, d0, d1);
@@ -7131,8 +7131,8 @@ result_t test_mm_hsubs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
             d16[i] = (int16_t) d32[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_hsubs_epi16(a, b);
 
     return validateInt16(c, d16[0], d16[1], d16[2], d16[3], d16[4], d16[5],
@@ -7158,8 +7158,8 @@ result_t test_mm_hsubs_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_hsubs_pi16(a, b);
 
     return validateInt16(c, _d[0], _d[1], _d[2], _d[3]);
@@ -7195,8 +7195,8 @@ result_t test_mm_maddubs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t e6 = saturate_16(d12 + d13);
     int16_t e7 = saturate_16(d14 + d15);
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_maddubs_epi16(a, b);
     return validateInt16(c, e0, e1, e2, e3, e4, e5, e6, e7);
 }
@@ -7219,8 +7219,8 @@ result_t test_mm_maddubs_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t e2 = saturate_16(d4 + d5);
     int16_t e3 = saturate_16(d6 + d7);
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_maddubs_pi16(a, b);
 
     return validateInt16(c, e0, e1, e2, e3);
@@ -7231,8 +7231,8 @@ result_t test_mm_mulhrs_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
     const int16_t *_b = (const int16_t *) impl.mTestIntPointer2;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     int32_t _c[8];
     for (int i = 0; i < 8; i++) {
         _c[i] =
@@ -7249,8 +7249,8 @@ result_t test_mm_mulhrs_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int16_t *_a = (const int16_t *) impl.mTestIntPointer1;
     const int16_t *_b = (const int16_t *) impl.mTestIntPointer2;
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     int32_t _c[4];
     for (int i = 0; i < 4; i++) {
         _c[i] =
@@ -7274,8 +7274,8 @@ result_t test_mm_shuffle_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
             dst[i] = _a[_b[i] & 0x0F];
         }
     }
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i ret = _mm_shuffle_epi8(a, b);
 
     return validateInt8(ret, dst[0], dst[1], dst[2], dst[3], dst[4], dst[5],
@@ -7297,8 +7297,8 @@ result_t test_mm_shuffle_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 ret = _mm_shuffle_pi8(a, b);
 
     return validateInt8(ret, dst[0], dst[1], dst[2], dst[3], dst[4], dst[5],
@@ -7321,8 +7321,8 @@ result_t test_mm_sign_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sign_epi16(a, b);
 
     return validateInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -7344,8 +7344,8 @@ result_t test_mm_sign_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_sign_epi32(a, b);
 
     return validateInt32(c, d[0], d[1], d[2], d[3]);
@@ -7367,8 +7367,8 @@ result_t test_mm_sign_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_sign_epi8(a, b);
 
     return validateInt8(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8],
@@ -7391,8 +7391,8 @@ result_t test_mm_sign_pi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_sign_pi16(a, b);
 
     return validateInt16(c, d[0], d[1], d[2], d[3]);
@@ -7414,8 +7414,8 @@ result_t test_mm_sign_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_sign_pi32(a, b);
 
     return validateInt32(c, d[0], d[1]);
@@ -7437,8 +7437,8 @@ result_t test_mm_sign_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m64 a = do_mm_load_m64((const int64_t *) _a);
-    __m64 b = do_mm_load_m64((const int64_t *) _b);
+    __m64 a = load_m64((const int64_t *) _a);
+    __m64 b = load_m64((const int64_t *) _b);
     __m64 c = _mm_sign_pi8(a, b);
 
     return validateInt8(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -7460,8 +7460,8 @@ result_t test_mm_blend_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_blend_epi16(a, b, mask);
 
     return validateInt16(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6],
@@ -7484,8 +7484,8 @@ result_t test_mm_blend_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128d a = do_mm_load_pd((const double *) _a);
-    __m128d b = do_mm_load_pd((const double *) _b);
+    __m128d a = load_m128d((const double *) _a);
+    __m128d b = load_m128d((const double *) _b);
     __m128d c = _mm_blend_pd(a, b, mask);
 
     return validateDouble(c, _c[0], _c[1]);
@@ -7507,8 +7507,8 @@ result_t test_mm_blend_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
 
     // gcc and clang can't compile call to _mm_blend_ps with 3rd argument as
     // integer type due 4 bit size limitation and test framework doesn't support
@@ -7593,9 +7593,9 @@ result_t test_mm_blendv_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
-    __m128i mask = do_mm_load_ps((const int32_t *) _mask);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
+    __m128i mask = load_m128i((const int32_t *) _mask);
     __m128i c = _mm_blendv_epi8(a, b, mask);
 
     return validateInt8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6],
@@ -7621,9 +7621,9 @@ result_t test_mm_blendv_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
-    __m128d mask = do_mm_load_pd(_mask);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
+    __m128d mask = load_m128d(_mask);
 
     __m128d c = _mm_blendv_pd(a, b, mask);
 
@@ -7649,9 +7649,9 @@ result_t test_mm_blendv_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
-    __m128 mask = do_mm_load_ps(_mask);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
+    __m128 mask = load_m128(_mask);
 
     __m128 c = _mm_blendv_ps(a, b, mask);
 
@@ -7665,7 +7665,7 @@ result_t test_mm_ceil_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double dx = ceil(_a[0]);
     double dy = ceil(_a[1]);
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d ret = _mm_ceil_pd(a);
 
     return validateDouble(ret, dx, dy);
@@ -7692,8 +7692,8 @@ result_t test_mm_ceil_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double dx = ceil(_b[0]);
     double dy = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d ret = _mm_ceil_sd(a, b);
 
     return validateDouble(ret, dx, dy);
@@ -7706,8 +7706,8 @@ result_t test_mm_ceil_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     float f0 = ceilf(_b[0]);
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_ceil_ss(a, b);
 
     return validateFloat(c, f0, _a[1], _a[2], _a[3]);
@@ -7720,8 +7720,8 @@ result_t test_mm_cmpeq_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t d0 = (_a[0] == _b[0]) ? 0xffffffffffffffff : 0x0;
     int64_t d1 = (_a[1] == _b[1]) ? 0xffffffffffffffff : 0x0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_cmpeq_epi64(a, b);
     return validateInt64(c, d0, d1);
 }
@@ -7735,7 +7735,7 @@ result_t test_mm_cvtepi16_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = (int32_t) _a[2];
     int32_t i3 = (int32_t) _a[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepi16_epi32(a);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -7748,7 +7748,7 @@ result_t test_mm_cvtepi16_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepi16_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7761,7 +7761,7 @@ result_t test_mm_cvtepi32_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     __m128i ret = _mm_cvtepi32_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7780,7 +7780,7 @@ result_t test_mm_cvtepi8_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t i6 = (int16_t) _a[6];
     int16_t i7 = (int16_t) _a[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepi8_epi16(a);
 
     return validateInt16(ret, i0, i1, i2, i3, i4, i5, i6, i7);
@@ -7795,7 +7795,7 @@ result_t test_mm_cvtepi8_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = (int32_t) _a[2];
     int32_t i3 = (int32_t) _a[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepi8_epi32(a);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -7808,7 +7808,7 @@ result_t test_mm_cvtepi8_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepi8_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7823,7 +7823,7 @@ result_t test_mm_cvtepu16_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = (int32_t) _a[2];
     int32_t i3 = (int32_t) _a[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu16_epi32(a);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -7836,7 +7836,7 @@ result_t test_mm_cvtepu16_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu16_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7849,7 +7849,7 @@ result_t test_mm_cvtepu32_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu32_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7868,7 +7868,7 @@ result_t test_mm_cvtepu8_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
     int16_t i6 = (int16_t) _a[6];
     int16_t i7 = (int16_t) _a[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu8_epi16(a);
 
     return validateInt16(ret, i0, i1, i2, i3, i4, i5, i6, i7);
@@ -7883,7 +7883,7 @@ result_t test_mm_cvtepu8_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t i2 = (int32_t) _a[2];
     int32_t i3 = (int32_t) _a[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu8_epi32(a);
 
     return validateInt32(ret, i0, i1, i2, i3);
@@ -7896,7 +7896,7 @@ result_t test_mm_cvtepu8_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     int64_t i0 = (int64_t) _a[0];
     int64_t i1 = (int64_t) _a[1];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_cvtepu8_epi64(a);
 
     return validateInt64(ret, i0, i1);
@@ -7916,8 +7916,8 @@ result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     for (size_t i = 0; i < 2; i++)
         d[i] = (imm & (1 << i)) ? sum : 0;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d ret = _mm_dp_pd(a, b, imm);
 
     return validateDouble(ret, d[0], d[1]);
@@ -7928,8 +7928,8 @@ result_t test_mm_dp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *_a = impl.mTestFloatPointer1;
     const float *_b = impl.mTestFloatPointer2;
     const int imm = 0xFF;
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 out = _mm_dp_ps(a, b, imm);
 
     float r[4]; /* the reference */
@@ -7948,7 +7948,7 @@ result_t test_mm_extract_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     int32_t *_a = (int32_t *) impl.mTestIntPointer1;
     const int idx = iter & 0x3;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     int c;
     switch (idx) {
     case 0:
@@ -7973,7 +7973,7 @@ result_t test_mm_extract_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     int64_t *_a = (int64_t *) impl.mTestIntPointer1;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __int64_t c;
 
     switch (iter & 0x1) {
@@ -7994,7 +7994,7 @@ result_t test_mm_extract_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint8_t *_a = (uint8_t *) impl.mTestIntPointer1;
     const int idx = iter & 0x7;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     int c;
     switch (idx) {
     case 0:
@@ -8060,7 +8060,7 @@ result_t test_mm_floor_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double dx = floor(_a[0]);
     double dy = floor(_a[1]);
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     __m128d ret = _mm_floor_pd(a);
 
     return validateDouble(ret, dx, dy);
@@ -8074,7 +8074,7 @@ result_t test_mm_floor_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dz = floorf(_a[2]);
     float dw = floorf(_a[3]);
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     __m128 c = _mm_floor_ps(a);
     return validateFloat(c, dx, dy, dz, dw);
 }
@@ -8087,8 +8087,8 @@ result_t test_mm_floor_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double dx = floor(_b[0]);
     double dy = _a[1];
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     __m128d ret = _mm_floor_sd(a, b);
 
     return validateDouble(ret, dx, dy);
@@ -8101,8 +8101,8 @@ result_t test_mm_floor_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     float f0 = floorf(_b[0]);
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     __m128 c = _mm_floor_ss(a, b);
 
     return validateFloat(c, f0, _a[1], _a[2], _a[3]);
@@ -8120,7 +8120,7 @@ result_t test_mm_insert_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
     d[imm8] = insert;
 
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
     __m128i b = _mm_insert_epi32(a, (int) insert, imm8);
     return validateInt32(b, d[0], d[1], d[2], d[3]);
 }
@@ -8137,7 +8137,7 @@ result_t test_mm_insert_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     d[1] = _a[1];
     d[imm8] = insert;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_insert_epi64(a, insert, imm8);
     return validateInt64(b, d[0], d[1]);
 }
@@ -8154,7 +8154,7 @@ result_t test_mm_insert_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
     d[imm8] = insert;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i b = _mm_insert_epi8(a, insert, imm8);
     return validateInt8(b, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8],
                         d[9], d[10], d[11], d[12], d[13], d[14], d[15]);
@@ -8192,8 +8192,8 @@ result_t test_mm_max_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = _a[2] > _b[2] ? _a[2] : _b[2];
     int32_t d3 = _a[3] > _b[3] ? _a[3] : _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_max_epi32(a, b);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -8220,8 +8220,8 @@ result_t test_mm_max_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = _a[14] > _b[14] ? _a[14] : _b[14];
     int8_t d15 = _a[15] > _b[15] ? _a[15] : _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
 
     __m128i c = _mm_max_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
@@ -8242,8 +8242,8 @@ result_t test_mm_max_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d6 = _a[6] > _b[6] ? _a[6] : _b[6];
     uint16_t d7 = _a[7] > _b[7] ? _a[7] : _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_max_epu16(a, b);
 
     return validateUInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -8259,8 +8259,8 @@ result_t test_mm_max_epu32(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint32_t d2 = _a[2] > _b[2] ? _a[2] : _b[2];
     uint32_t d3 = _a[3] > _b[3] ? _a[3] : _b[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_max_epu32(a, b);
 
     return validateUInt32(c, d0, d1, d2, d3);
@@ -8276,8 +8276,8 @@ result_t test_mm_min_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t d2 = _a[2] < _b[2] ? _a[2] : _b[2];
     int32_t d3 = _a[3] < _b[3] ? _a[3] : _b[3];
 
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_min_epi32(a, b);
 
     return validateInt32(c, d0, d1, d2, d3);
@@ -8305,8 +8305,8 @@ result_t test_mm_min_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     int8_t d14 = _a[14] < _b[14] ? _a[14] : _b[14];
     int8_t d15 = _a[15] < _b[15] ? _a[15] : _b[15];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
 
     __m128i c = _mm_min_epi8(a, b);
     return validateInt8(c, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11,
@@ -8327,8 +8327,8 @@ result_t test_mm_min_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d6 = _a[6] < _b[6] ? _a[6] : _b[6];
     uint16_t d7 = _a[7] < _b[7] ? _a[7] : _b[7];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_min_epu16(a, b);
 
     return validateUInt16(c, d0, d1, d2, d3, d4, d5, d6, d7);
@@ -8344,8 +8344,8 @@ result_t test_mm_min_epu32(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint32_t d2 = _a[2] < _b[2] ? _a[2] : _b[2];
     uint32_t d3 = _a[3] < _b[3] ? _a[3] : _b[3];
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_min_epu32(a, b);
 
     return validateUInt32(c, d0, d1, d2, d3);
@@ -8365,7 +8365,7 @@ result_t test_mm_minpos_epu16(const SSE2NEONTestImpl &impl, uint32_t iter)
     uint16_t d1 = index;
     uint16_t d2 = 0, d3 = 0, d4 = 0, d5 = 0, d6 = 0, d7 = 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
+    __m128i a = load_m128i((const int32_t *) _a);
     __m128i ret = _mm_minpos_epu16(a);
     return validateUInt16(ret, d0, d1, d2, d3, d4, d5, d6, d7);
 }
@@ -8386,8 +8386,8 @@ result_t test_mm_mpsadbw_epu8(const SSE2NEONTestImpl &impl, uint32_t iter)
         }
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c;
     switch (imm & 0x7) {
     case 0:
@@ -8446,8 +8446,8 @@ result_t test_mm_mullo_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     for (int i = 0; i < 4; i++) {
         d[i] = (int32_t)((int64_t) _a[i] * (int64_t) _b[i]);
     }
-    __m128i a = do_mm_load_ps(_a);
-    __m128i b = do_mm_load_ps(_b);
+    __m128i a = load_m128i(_a);
+    __m128i b = load_m128i(_b);
     __m128i c = _mm_mullo_epi32(a, b);
     return validateInt32(c, d[0], d[1], d[2], d[3]);
 }
@@ -8477,8 +8477,8 @@ result_t test_mm_packus_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
             d[i + 4] = (uint16_t) _b[i];
     }
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i c = _mm_packus_epi32(a, b);
 
     return validateUInt16(c, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]);
@@ -8490,7 +8490,7 @@ result_t test_mm_round_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d[2];
     __m128d ret;
 
-    __m128d a = do_mm_load_pd(_a);
+    __m128d a = load_m128d(_a);
     switch (iter & 0x7) {
     case 0:
         d[0] = bankersRounding(_a[0]);
@@ -8555,7 +8555,7 @@ result_t test_mm_round_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f[4];
     __m128 ret;
 
-    __m128 a = do_mm_load_ps(_a);
+    __m128 a = load_m128(_a);
     switch (iter & 0x7) {
     case 0:
         f[0] = bankersRounding(_a[0]);
@@ -8637,8 +8637,8 @@ result_t test_mm_round_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     double d[2];
     __m128d ret;
 
-    __m128d a = do_mm_load_pd(_a);
-    __m128d b = do_mm_load_pd(_b);
+    __m128d a = load_m128d(_a);
+    __m128d b = load_m128d(_b);
     d[1] = _a[1];
     switch (iter & 0x7) {
     case 0:
@@ -8697,8 +8697,8 @@ result_t test_mm_round_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float f[4];
     __m128 ret;
 
-    __m128 a = do_mm_load_ps(_a);
-    __m128 b = do_mm_load_ps(_b);
+    __m128 a = load_m128(_a);
+    __m128 b = load_m128(_b);
     switch (iter & 0x7) {
     case 0:
         f[0] = bankersRounding(_b[0]);
@@ -8765,7 +8765,7 @@ result_t test_mm_stream_load_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_test_all_ones(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
-    __m128i a = do_mm_load_ps(_a);
+    __m128i a = load_m128i(_a);
 
     int32_t d0 = ~_a[0] & (~(uint32_t) 0);
     int32_t d1 = ~_a[1] & (~(uint32_t) 0);
@@ -8782,8 +8782,8 @@ result_t test_mm_test_all_zeros(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     const int32_t *_mask = (const int32_t *) impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i mask = do_mm_load_ps(_mask);
+    __m128i a = load_m128i(_a);
+    __m128i mask = load_m128i(_mask);
 
     int32_t d0 = _a[0] & _mask[0];
     int32_t d1 = _a[1] & _mask[1];
@@ -8801,8 +8801,8 @@ result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl,
 {
     const int32_t *_a = (const int32_t *) impl.mTestIntPointer1;
     const int32_t *_mask = (const int32_t *) impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps(_a);
-    __m128i mask = do_mm_load_ps(_mask);
+    __m128i a = load_m128i(_a);
+    __m128i mask = load_m128i(_mask);
 
     int32_t d0 = !((_a[0]) & _mask[0]) & !((!_a[0]) & _mask[0]);
     int32_t d1 = !((_a[1]) & _mask[1]) & !((!_a[1]) & _mask[1]);
@@ -8898,8 +8898,8 @@ result_t test_mm_cmpgt_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[0] = _a[0] > _b[0] ? -1 : 0;
     result[1] = _a[1] > _b[1] ? -1 : 0;
 
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     __m128i iret = _mm_cmpgt_epi64(a, b);
 
     return validateInt64(iret, result[0], result[1]);
@@ -9027,8 +9027,8 @@ result_t test_mm_clmulepi64_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const uint64_t *_a = (const uint64_t *) impl.mTestIntPointer1;
     const uint64_t *_b = (const uint64_t *) impl.mTestIntPointer2;
-    __m128i a = do_mm_load_ps((const int32_t *) _a);
-    __m128i b = do_mm_load_ps((const int32_t *) _b);
+    __m128i a = load_m128i((const int32_t *) _a);
+    __m128i b = load_m128i((const int32_t *) _b);
     auto result = clmul_64(_a[0], _b[0]);
     if (!validateUInt64(_mm_clmulepi64_si128(a, b, 0x00), result.first,
                         result.second))


### PR DESCRIPTION
The functions for loading the __m64, __m128, __128i and __m128d data
from address are changed to the version which does not need to be
aligned on any particular boundary.
The name of the functions are changed to a more intuitive naming and do not
bound with the intrinsic name.