### PR TITLE
refactor: Rewrite _mm_alignr_epi8() to function

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -6545,29 +6545,23 @@ FORCE_INLINE __m64 _mm_abs_pi8(__m64 a)
 //   dst[127:0] := tmp[127:0]
 //
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_alignr_epi8
-#define _mm_alignr_epi8(a, b, imm)                                            \
-    __extension__({                                                           \
-        __m128i ret;                                                          \
-        if (_sse2neon_unlikely((imm) >= 32)) {                                \
-            ret = _mm_setzero_si128();                                        \
-        } else {                                                              \
-            uint8x16_t tmp_low, tmp_high;                                     \
-            if (imm >= 16) {                                                  \
-                const int idx = imm - 16;                                     \
-                tmp_low = vreinterpretq_u8_m128i(a);                          \
-                tmp_high = vdupq_n_u8(0);                                     \
-                ret =                                                         \
-                    vreinterpretq_m128i_u8(vextq_u8(tmp_low, tmp_high, idx)); \
-            } else {                                                          \
-                const int idx = imm;                                          \
-                tmp_low = vreinterpretq_u8_m128i(b);                          \
-                tmp_high = vreinterpretq_u8_m128i(a);                         \
-                ret =                                                         \
-                    vreinterpretq_m128i_u8(vextq_u8(tmp_low, tmp_high, idx)); \
-            }                                                                 \
-        }                                                                     \
-        ret;                                                                  \
-    })
+FORCE_INLINE __m128i _mm_alignr_epi8(__m128i a, __m128i b, int imm)
+{
+    if (_sse2neon_unlikely((unsigned int) imm >= 32))
+        return _mm_setzero_si128();
+    int idx;
+    uint8x16_t tmp[2];
+    if (imm >= 16) {
+        idx = imm - 16;
+        tmp[0] = vreinterpretq_u8_m128i(a);
+        tmp[1] = vdupq_n_u8(0);
+    } else {
+        idx = imm;
+        tmp[0] = vreinterpretq_u8_m128i(b);
+        tmp[1] = vreinterpretq_u8_m128i(a);
+    }
+    return vreinterpretq_m128i_u8(vld1q_u8(((uint8_t const *) tmp) + idx));
+}
 
 // Concatenate 8-byte blocks in a and b into a 16-byte temporary result, shift
 // the result right by imm8 bytes, and store the low 8 bytes in dst.

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -6879,8 +6879,7 @@ result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 #else
     const uint8_t *_a = (const uint8_t *) impl.mTestIntPointer1;
     const uint8_t *_b = (const uint8_t *) impl.mTestIntPointer2;
-    // FIXME: The different immediate value should be tested in the future
-    const int shift = 18;
+    unsigned int shift = (iter % 5) << 3;
     uint8_t d[32];
 
     if (shift >= 32) {
@@ -6899,7 +6898,24 @@ result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     __m128i a = load_m128i(_a);
     __m128i b = load_m128i(_b);
-    __m128i ret = _mm_alignr_epi8(a, b, shift);
+    __m128i ret;
+    switch (iter % 5) {
+    case 0:
+        ret = _mm_alignr_epi8(a, b, 0);
+        break;
+    case 1:
+        ret = _mm_alignr_epi8(a, b, 8);
+        break;
+    case 2:
+        ret = _mm_alignr_epi8(a, b, 16);
+        break;
+    case 3:
+        ret = _mm_alignr_epi8(a, b, 24);
+        break;
+    case 4:
+        ret = _mm_alignr_epi8(a, b, 32);
+        break;
+    }
 
     return validateUInt8(ret, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7],
                          d[8], d[9], d[10], d[11], d[12], d[13], d[14], d[15]);


### PR DESCRIPTION
The test has been rewritten for testing more immediate values.
The selected values are able to represent different scenarios.

The implementation replaces vextq_u8() with vld1q_u8() since the latter
does not require constant immediate value.
As the immediate value is not required, the implementation can be
changed from macro to function.

The commit fixes the issue #482 as well.

Close #482.