### PR TITLE
fix: Add precise implementation of _mm_dp_pd()

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Considering the balance between correctness and performance, `sse2neon` recogniz
 * `SSE2NEON_PRECISE_MINMAX`: Enable precise implementation of `_mm_min_ps` and `_mm_max_ps`. If you need consistent results such as NaN special cases, enable it.
 * `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_DP`: Enable precise implementation of `_mm_dp_pd`. When the conditional bit is not set, the corresponding multiplication would not be executed.
 
 The above are turned off by default, and you should define the corresponding macro(s) as `1` before including `sse2neon.h` if you need the precise implementations.
 


### PR DESCRIPTION
The commit adds the new macro SSE2NEON_PRECISE_DP for precise
implementation of _mm_dp_pd().
The precise implementation removes the possible extra multiplications.
Enable the macro might decrease the performance but the behaviour
would be matched with the intrinsic description of Intel Intrinsics Guide.

Close #480.