### PR TITLE
Add parentheses around imm in some macros

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -6700,13 +6700,13 @@ FORCE_INLINE __m128i _mm_alignr_epi8(__m128i a, __m128i b, int imm)
             ret = vreinterpret_m64_s8(vdup_n_s8(0));                        \
         } else {                                                            \
             uint8x8_t tmp_low, tmp_high;                                    \
-            if ((imm) >= 8) {                                                 \
-                const int idx = (imm) - 8;                                    \
+            if ((imm) >= 8) {                                               \
+                const int idx = (imm) -8;                                   \
                 tmp_low = vreinterpret_u8_m64(a);                           \
                 tmp_high = vdup_n_u8(0);                                    \
                 ret = vreinterpret_m64_u8(vext_u8(tmp_low, tmp_high, idx)); \
             } else {                                                        \
-                const int idx = (imm);                                        \
+                const int idx = (imm);                                      \
                 tmp_low = vreinterpret_u8_m64(b);                           \
                 tmp_high = vreinterpret_u8_m64(a);                          \
                 ret = vreinterpret_m64_u8(vext_u8(tmp_low, tmp_high, idx)); \


### PR DESCRIPTION
Some of the macros like _mm_srli_epi32 take an argument named imm.  I added parentheses around (imm) in the body of the macro.  Otherwise if the macro is called with an expression for imm, the macro will evaluate incorrectly.  