### PR TITLE
Add support for 32-bit targets on ARMv8 architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ but SSE intrinsic `_mm_maddubs_epi16` has to be implemented with 13+ NEON instru
 ```
 
 - Explicitly specify platform-specific options to gcc/clang compilers.
-  * On ARMv8-A targets, you should specify the following compiler option: (Remove `crypto` and/or `crc` if your architecture does not support cryptographic and/or CRC32 extensions)
+  * On ARMv8-A 64-bit targets, you should specify the following compiler option: (Remove `crypto` and/or `crc` if your architecture does not support cryptographic and/or CRC32 extensions)
   ```shell
   -march=armv8-a+fp+simd+crypto+crc
+  ```
+  * On ARMv8-A 32-bit targets, you should specify the following compiler option:
+  ```shell
+  -mfpu=neon-fp-armv8
   ```
   * On ARMv7-A targets, you need to append the following compiler option:
   ```shell

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -121,6 +121,12 @@
 #pragma GCC push_options
 #pragma GCC target("+simd")
 #endif
+#elif __ARM_ARCH == 8
+#if !defined(__ARM_NEON) || !defined(__ARM_NEON__)
+#error \
+    "You must enable NEON instructions (e.g. -mfpu=neon-fp-armv8) to use SSE2NEON."
+#endif
+#pragma GCC push_options
 #else
 #error "Unsupported target. Must be either ARMv7-A+NEON or ARMv8-A."
 #endif


### PR DESCRIPTION
This adds support for using sse2neon when building 32-bit executables to run on ARMv8 architectures.  Prior to this change, you could not use sse2neon when building a 32-bit executable while targeting ARMv8.  So you couldn't do this:

$ clang++ -O2 -mcpu=cortex-a73 -mfpu=neon-fp-armv8 myprogram.cpp

when the target was armv7l-unknown-linux-gnueabihf, as sse2neon looks for __ARM_ARCH == 7, or __aarch64__ defined, and neither is true for a 32-bit executable targeting ARMv8.