### PR TITLE
Remove designated initialization of an array

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -8834,7 +8834,7 @@ enum {
 };
 typedef int (*cmpestr_func_t)(__m128i a, int la, __m128i b, int lb);
 static cmpestr_func_t _sse2neon_cmpfunc_table[] = {
-#define _(name, func_suffix) [name] = _sse2neon_##func_suffix,
+#define _(name, func_suffix) _sse2neon_##func_suffix,
     SSE2NEON_CMPESTR_LIST
 #undef _
 };


### PR DESCRIPTION
C supports designated initialization of arrays, but C++ does not. The one usage of it does not serve a functional purpose and so can be removed. This code was triggering warnings under clang and errors under MSVC.