### PR TITLE
Reintroduce `ext`-based implementations for shift intrinsics

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -6736,23 +6736,20 @@ FORCE_INLINE __m64 _mm_abs_pi8(__m64 a)
 //   dst[127:0] := tmp[127:0]
 //
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_alignr_epi8
-FORCE_INLINE __m128i _mm_alignr_epi8(__m128i a, __m128i b, int imm)
-{
-    if (_sse2neon_unlikely(imm & ~31))
-        return _mm_setzero_si128();
-    int idx;
-    uint8x16_t tmp[2];
-    if (imm >= 16) {
-        idx = imm - 16;
-        tmp[0] = vreinterpretq_u8_m128i(a);
-        tmp[1] = vdupq_n_u8(0);
-    } else {
-        idx = imm;
-        tmp[0] = vreinterpretq_u8_m128i(b);
-        tmp[1] = vreinterpretq_u8_m128i(a);
-    }
-    return vreinterpretq_m128i_u8(vld1q_u8(((uint8_t const *) tmp) + idx));
-}
+#define _mm_alignr_epi8(a, b, imm)                                            \
+    __extension__({                                                           \
+        uint8x16_t _a = vreinterpretq_u8_m128i(a);                            \
+        uint8x16_t _b = vreinterpretq_u8_m128i(b);                            \
+        __m128i ret;                                                          \
+        if (_sse2neon_unlikely((imm) & ~31))                                  \
+            ret = vreinterpretq_m128i_u8(vdupq_n_u8(0));                      \
+        else if (imm >= 16)                                                   \
+            ret = _mm_srli_si128(a, imm >= 16 ? imm - 16 : 0);                \
+        else                                                                  \
+            ret =                                                             \
+                vreinterpretq_m128i_u8(vextq_u8(_b, _a, imm < 16 ? imm : 0)); \
+        ret;                                                                  \
+    })
 
 // Concatenate 8-byte blocks in a and b into a 16-byte temporary result, shift
 // the result right by imm8 bytes, and store the low 8 bytes in dst.


### PR DESCRIPTION
Use the vector extract instruction (ext) to implement `_mm_srli_si128`,
`_mm_slli_si128` and `_mm_alignr_epi8`, significantly improving performance
by avoiding memory.

These were originally changed in #483 and #484 to instead use a store
followed by a shifted load. This was done in order to resolve issue
#482, where the compiler would throw an error if there were an invalid
immediate in the intrinsic arguments after the macros are expanded.

These commits avoid the recurrence of this issue by guarding the
immediate arguments with additional (redundant) ternary expressions.
These are evaluated at compile time and should cause no performance
loss; they only prevent the compilers from attempting to propagate
invalid immediates. This does now require that the immediate argument
to these intrinsics be a compile-time constant expression, but this
matches the requirement imposed by the original SSE intrinsics.

Sample codegen diffs are included in the individual commit messages.