### PR TITLE
Add clang/Windows build

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -19,6 +19,37 @@ jobs:
           make check
           sh .ci/cross-check.sh
 
+  host_win:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - armv7
+          - aarch64
+    env:
+      LLVM_MINGW_URL: https://github.com/mstorsjo/llvm-mingw/releases/download/20220906/llvm-mingw-20220906-ucrt-x86_64.zip
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: unpack llvm-mingw
+        run: |
+          curl -L -O $LLVM_MINGW_URL
+          unzip -q llvm-mingw-*.zip
+          rm llvm-mingw-*.zip
+          mv llvm-mingw-* "$HOME/llvm-mingw"
+          echo "$HOME/llvm-mingw/bin" >> $GITHUB_PATH
+      - name: checkout code
+        uses: actions/checkout@v3.0.2
+      - name: build artifact
+        env:
+          CXX: ${{ matrix.arch }}-w64-mingw32-clang++
+        run: mingw32-make processor=${{ matrix.arch }}
+      - name: run tests
+        if: matrix.arch == 'x86_64'
+        run: mingw32-make check
+
   host_arm:
     runs-on: ubuntu-20.04
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.exe
 *.o
 *.gch
 tests/*.d

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifeq ($(processor),$(filter $(processor),aarch64 arm64))
     ARCH_CFLAGS = -march=armv8-a+fp+simd+crc
 else ifeq ($(processor),$(filter $(processor),i386 x86_64))
     ARCH_CFLAGS = -maes -mpclmul -mssse3 -msse4.2
-else ifeq ($(processor),$(filter $(processor),arm armv7l))
+else ifeq ($(processor),$(filter $(processor),arm armv7 armv7l))
     ARCH_CFLAGS = -mfpu=neon
 else
     $(error Unsupported architecture)

--- a/tests/binding.cpp
+++ b/tests/binding.cpp
@@ -8,8 +8,13 @@ namespace SSE2NEON
 void *platformAlignedAlloc(size_t size)
 {
     void *address;
+#if defined(_WIN32)
+    address = _aligned_malloc(size, 16);
+    if (!address) {
+#else
     int ret = posix_memalign(&address, 16, size);
     if (ret != 0) {
+#endif
         fprintf(stderr, "Error at File %s line number %d\n", __FILE__,
                 __LINE__);
         exit(EXIT_FAILURE);
@@ -19,7 +24,12 @@ void *platformAlignedAlloc(size_t size)
 
 void platformAlignedFree(void *ptr)
 {
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#else
     free(ptr);
+#endif
 }
+
 
 }  // namespace SSE2NEON

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -5997,7 +5997,7 @@ result_t test_mm_sqrt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128d a = load_m128d(_a);
     __m128d c = _mm_sqrt_pd(a);
 
-    return validateDouble(c, f0, f1);
+    return validateFloatError(c, f0, f1, 1.0e-15);
 }
 
 result_t test_mm_sqrt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -6012,7 +6012,7 @@ result_t test_mm_sqrt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128d b = load_m128d(_b);
     __m128d c = _mm_sqrt_sd(a, b);
 
-    return validateDouble(c, f0, f1);
+    return validateFloatError(c, f0, f1, 1.0e-15);
 }
 
 result_t test_mm_sra_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)


### PR DESCRIPTION
Add Windows CI build using [llvm-mingw](https://github.com/mstorsjo/llvm-mingw), a standalone clang/mingw-w64 toolchain that supports cross compiling.

- Windows builds are produced for x86_64, armv7, and aarch64.
- Tests are only run on x86_64. GitHub does not provide public Windows on ARM64 runners, and there is no qemu-user equivalent on Windows.
- The test framework is updated to support Windows aligned malloc/free APIs.
- The sqrt_sd/pd tests now use an epsilon for comparing results just like the sqrt_ss/ps tests. This is necessary because mingw-w64 implements C sqrt() using x87 rather than SSE.
- In case you are wondering why clang but not GCC: there are currently no builds of GCC that target Windows on ARM64.