### PR TITLE
fix: Assign architecture in CI job host_x86 

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+        arch: [x86_64]
         cxx_compiler: [g++-10, clang++-11]
     steps:
       - name: checkout code


### PR DESCRIPTION
This PR assigns the architecture, x86_64 in GitHub Actions job
'host_x86'.