### PR TITLE
test: Build/run with crypto and/or crc

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [armv7, aarch64]
+        arch_with_features: [{arch: armv7, feature: none}, {arch: aarch64, feature: none}, {arch: aarch64, feature: crypto+crc}]
         cxx_compiler: [g++-10, clang++-11]
     steps:
       - name: checkout code
@@ -65,7 +65,7 @@ jobs:
         # https://github.com/uraimo/run-on-arch-action
         uses: uraimo/run-on-arch-action@v2.5.0
         with:
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.arch_with_features.arch }}
           distro: ubuntu20.04
           env: |
             CXX: ${{ matrix.cxx_compiler }}
@@ -73,7 +73,8 @@ jobs:
             apt-get update -q -y
             apt-get install -q -y "${{ matrix.cxx_compiler }}" make
             apt-get install -q -y gcc
-          run: make check
+          run: |
+            make FEATURE=${{ matrix.arch_with_features.feature }} check
 
   coding_style:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,21 @@ endif
 
 # Follow platform-specific configurations
 ifeq ($(processor),$(filter $(processor),aarch64 arm64))
-    ARCH_CFLAGS = -march=armv8-a+fp+simd+crc
+    ARCH_CFLAGS = -march=armv8-a+fp+simd
 else ifeq ($(processor),$(filter $(processor),i386 x86_64))
     ARCH_CFLAGS = -maes -mpclmul -mssse3 -msse4.2
 else ifeq ($(processor),$(filter $(processor),arm armv7 armv7l))
     ARCH_CFLAGS = -mfpu=neon
 else
     $(error Unsupported architecture)
+endif
+
+FEATURE ?=
+ifneq ($(FEATURE),)
+ifneq ($(FEATURE),none)
+COMMA:= ,
+ARCH_CFLAGS := $(ARCH_CFLAGS)+$(subst $(COMMA),+,$(FEATURE))
+endif
 endif
 
 CXXFLAGS += -Wall -Wcast-qual -I. $(ARCH_CFLAGS) -std=gnu++14

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ runtime. Use the following commands to perform test cases:
 $ make check
 ```
 
+For running check with enabling features, you can use assign the features with `FEATURE` command.
+If `none` is assigned, then the command will be the same as simply calling `make check`.
+The following command enable `crypto` and `crc` features in the tests.
+```
+$ make FEATURE=crypto+crc check
+```
+
 You can specify GNU toolchain for cross compilation as well.
 [QEMU](https://www.qemu.org/) should be installed in advance.
 ```shell


### PR DESCRIPTION
The current test has a lack of tests with crypto flag enabled which cause the tests not cover the total implementation.