### PR TITLE
Improve precision of _mm_{rsqrt,sqrt,rcp,div}_{ps,ss} conversions

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -11,7 +11,7 @@ jobs:
         cxx_compiler: [g++-10, clang++-11]
     steps:
       - name: checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.2.0
       - name: build artifact
         env:
           CXX: ${{ matrix.cxx_compiler }}
@@ -42,7 +42,7 @@ jobs:
           mv llvm-mingw-* "$HOME/llvm-mingw"
           echo "$HOME/llvm-mingw/bin" >> $GITHUB_PATH
       - name: checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.2.0
       - name: build artifact
         env:
           CXX: ${{ matrix.arch }}-w64-mingw32-clang++
@@ -63,7 +63,7 @@ jobs:
       - name: build artifact
         # The Github Action for non-x86 CPU
         # https://github.com/uraimo/run-on-arch-action
-        uses: uraimo/run-on-arch-action@v2.3.0
+        uses: uraimo/run-on-arch-action@v2.5.0
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ but SSE intrinsic `_mm_maddubs_epi16` has to be implemented with 13+ NEON instru
 
 Considering the balance between correctness and performance, `sse2neon` recognizes the following compile-time configurations:
 * `SSE2NEON_PRECISE_MINMAX`: Enable precise implementation of `_mm_min_ps` and `_mm_max_ps`. If you need consistent results such as NaN special cases, enable it.
-* `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_DP`: Enable precise implementation of `_mm_dp_pd`. When the conditional bit is not set, the corresponding multiplication would not be executed.
 

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -9889,7 +9889,7 @@ FORCE_INLINE __m128i _mm_aesenclast_si128(__m128i a, __m128i RoundKey)
 FORCE_INLINE __m128i _mm_aesdeclast_si128(__m128i a, __m128i RoundKey)
 {
     return vreinterpretq_m128i_u8(
-               vaesdq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0))) ^
+               vaesdq_u8(vreinterpretq_u8_m128i(a), vdupq_n_u8(0)) ^
            vreinterpretq_u8_m128i(RoundKey);
 }
 

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -9811,17 +9811,35 @@ FORCE_INLINE __m128i _mm_aesimc_si128(__m128i a)
 // https://kazakov.life/2017/11/01/cryptocurrency-mining-on-ios-devices/
 // for details.
 //
-// https://msdn.microsoft.com/en-us/library/cc714138(v=vs.120).aspx
-FORCE_INLINE __m128i _mm_aeskeygenassist_si128(__m128i key, const int rcon)
+// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_aeskeygenassist_si128
+FORCE_INLINE __m128i _mm_aeskeygenassist_si128(__m128i a, const int rcon)
 {
-    uint32_t X1 = _mm_cvtsi128_si32(_mm_shuffle_epi32(key, 0x55));
-    uint32_t X3 = _mm_cvtsi128_si32(_mm_shuffle_epi32(key, 0xFF));
+#if defined(__aarch64__)
+    uint8x16_t _a = vreinterpretq_u8_m128i(a);
+    uint8x16_t v = vqtbl4q_u8(_sse2neon_vld1q_u8_x4(_sse2neon_sbox), _a);
+    v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_sbox + 0x40), _a - 0x40);
+    v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_sbox + 0x80), _a - 0x80);
+    v = vqtbx4q_u8(v, _sse2neon_vld1q_u8_x4(_sse2neon_sbox + 0xc0), _a - 0xc0);
+
+    uint32x4_t select_mask = {0xffffffff, 0x0, 0xffffffff, 0x0};
+    uint64x2_t v_mask = vshrq_n_u64(vreinterpretq_u64_u8(v), 32);
+    uint32x4_t x = vbslq_u32(select_mask, vreinterpretq_u32_u64(v_mask),
+                             vreinterpretq_u32_u8(v));
+    uint32x4_t ror_x = vorrq_u32(vshrq_n_u32(x, 8), vshlq_n_u32(x, 24));
+    uint32x4_t ror_xor_x = veorq_u32(ror_x, vdupq_n_u32(rcon));
+
+    return vreinterpretq_m128i_u32(vbslq_u32(select_mask, x, ror_xor_x));
+
+#else /* ARMv7-A NEON implementation */
+    uint32_t X1 = _mm_cvtsi128_si32(_mm_shuffle_epi32(a, 0x55));
+    uint32_t X3 = _mm_cvtsi128_si32(_mm_shuffle_epi32(a, 0xFF));
     for (int i = 0; i < 4; ++i) {
         ((uint8_t *) &X1)[i] = _sse2neon_sbox[((uint8_t *) &X1)[i]];
         ((uint8_t *) &X3)[i] = _sse2neon_sbox[((uint8_t *) &X3)[i]];
     }
     return _mm_set_epi32(((X3 >> 8) | (X3 << 24)) ^ rcon, X3,
                          ((X1 >> 8) | (X1 << 24)) ^ rcon, X1);
+#endif
 }
 #undef SSE2NEON_AES_SBOX
 #undef SSE2NEON_AES_RSBOX

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -316,6 +316,23 @@ result_t validateFloatEpsilon(__m128 a,
     float df1 = fabsf(t[1] - f1);
     float df2 = fabsf(t[2] - f2);
     float df3 = fabsf(t[3] - f3);
+
+    if ((std::isnan(t[0]) && std::isnan(f0)) || (t[0] == 0 && f0 == 0)) {
+        df0 = 0;
+    }
+
+    if ((std::isnan(t[1]) && std::isnan(f1)) || (t[1] == 0 && f1 == 0)) {
+        df1 = 0;
+    }
+
+    if ((std::isnan(t[2]) && std::isnan(f2)) || (t[2] == 0 && f2 == 0)) {
+        df2 = 0;
+    }
+
+    if ((std::isnan(t[3]) && std::isnan(f3)) || (t[3] == 0 && f3 == 0)) {
+        df3 = 0;
+    }
+
     ASSERT_RETURN(df0 < epsilon);
     ASSERT_RETURN(df1 < epsilon);
     ASSERT_RETURN(df2 < epsilon);

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -1855,7 +1855,8 @@ result_t test_mm_div_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     // The implementation of "_mm_div_ps()" on ARM 32bit doesn't use "DIV"
     // instruction directly, instead it uses "FRECPE" instruction to approximate
     // it. Therefore, the precision is not as small as other architecture
-    return validateFloatError(c, f0, f1, f2, f3, 0.00001f);
+    //return validateFloatError(c, f0, f1, f2, f3, 0.00001f);
+    return validateFloatEpsilon(c, d0, d1, d2, d3, FLT_EPSILON * 2);
 #else
     return validateFloat(c, f0, f1, f2, f3);
 #endif
@@ -1879,7 +1880,8 @@ result_t test_mm_div_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     // The implementation of "_mm_div_ps()" on ARM 32bit doesn't use "DIV"
     // instruction directly, instead it uses "FRECPE" instruction to approximate
     // it. Therefore, the precision is not as small as other architecture
-    return validateFloatError(c, d0, d1, d2, d3, 0.00001f);
+    //return validateFloatError(c, d0, d1, d2, d3, 0.00001f);
+    return validateFloatEpsilon(c, d0, d1, d2, d3, FLT_EPSILON * 2);
 #else
     return validateFloat(c, d0, d1, d2, d3);
 #endif
@@ -2573,7 +2575,8 @@ result_t test_mm_rcp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ps(a);
-    return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
+    //return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
+    return validateFloatError(c, dx, dy, dz, dw, 0.0001f);
 }
 
 result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2846,7 +2849,8 @@ result_t test_mm_sqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
+    //return validateFloatError(c, f0, f1, f2, f3, 0.001f);
+    return validateFloatEpsilon(c, f0, f1, f2, f3, FLT_EPSILON * 2);
 }
 
 result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2863,7 +2867,8 @@ result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
+    //return validateFloatError(c, f0, f1, f2, f3, 0.001f);
+    return validateFloatEpsilon(c, f0, f1, f2, f3, FLT_EPSILON * 2);
 }
 
 result_t test_mm_store_ps(const SSE2NEONTestImpl &impl, uint32_t iter)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2602,9 +2602,9 @@ result_t test_mm_rsqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ps(a);
 
-    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_rsqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2619,9 +2619,9 @@ result_t test_mm_rsqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ss(a);
 
-    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_sad_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2844,9 +2844,9 @@ result_t test_mm_sqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ps(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2861,9 +2861,9 @@ result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ss(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_store_ps(const SSE2NEONTestImpl &impl, uint32_t iter)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -1855,8 +1855,7 @@ result_t test_mm_div_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     // The implementation of "_mm_div_ps()" on ARM 32bit doesn't use "DIV"
     // instruction directly, instead it uses "FRECPE" instruction to approximate
     // it. Therefore, the precision is not as small as other architecture
-    //return validateFloatError(c, f0, f1, f2, f3, 0.00001f);
-    return validateFloatEpsilon(c, d0, d1, d2, d3, FLT_EPSILON * 2);
+    return validateFloatError(c, f0, f1, f2, f3, 0.000001f);
 #else
     return validateFloat(c, f0, f1, f2, f3);
 #endif
@@ -1880,8 +1879,7 @@ result_t test_mm_div_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     // The implementation of "_mm_div_ps()" on ARM 32bit doesn't use "DIV"
     // instruction directly, instead it uses "FRECPE" instruction to approximate
     // it. Therefore, the precision is not as small as other architecture
-    //return validateFloatError(c, d0, d1, d2, d3, 0.00001f);
-    return validateFloatEpsilon(c, d0, d1, d2, d3, FLT_EPSILON * 2);
+    return validateFloatError(c, d0, d1, d2, d3, 0.000001f);
 #else
     return validateFloat(c, d0, d1, d2, d3);
 #endif
@@ -2575,8 +2573,7 @@ result_t test_mm_rcp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ps(a);
-    //return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
-    return validateFloatError(c, dx, dy, dz, dw, 0.0001f);
+    return validateFloatError(c, dx, dy, dz, dw, 0.001f);
 }
 
 result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2590,7 +2587,7 @@ result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ss(a);
-    return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
+    return validateFloatError(c, dx, dy, dz, dw, 0.001f);
 }
 
 result_t test_mm_rsqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2847,10 +2844,9 @@ result_t test_mm_sqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ps(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
-    // to the C implementation.
-    //return validateFloatError(c, f0, f1, f2, f3, 0.001f);
-    return validateFloatEpsilon(c, f0, f1, f2, f3, FLT_EPSILON * 2);
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 10^-6%
+    // compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.000001f);
 }
 
 result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2865,10 +2861,9 @@ result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ss(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 0.1% compared
-    // to the C implementation.
-    //return validateFloatError(c, f0, f1, f2, f3, 0.001f);
-    return validateFloatEpsilon(c, f0, f1, f2, f3, FLT_EPSILON * 2);
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 10^-6%
+    // compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.000001f);
 }
 
 result_t test_mm_store_ps(const SSE2NEONTestImpl &impl, uint32_t iter)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -11628,12 +11628,12 @@ result_t test_mm_aesimc_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validate128(result_reference, result_intrinsic);
 }
 
-static inline uint32_t sub_word(uint32_t key)
+static inline uint32_t sub_word(uint32_t in)
 {
-    return (crypto_aes_sbox[(key >> 24) & 0xff] << 24) |
-           (crypto_aes_sbox[(key >> 16) & 0xff] << 16) |
-           (crypto_aes_sbox[(key >> 8) & 0xff] << 8) |
-           (crypto_aes_sbox[key & 0xff]);
+    return (crypto_aes_sbox[(in >> 24) & 0xff] << 24) |
+           (crypto_aes_sbox[(in >> 16) & 0xff] << 16) |
+           (crypto_aes_sbox[(in >> 8) & 0xff] << 8) |
+           (crypto_aes_sbox[in & 0xff]);
 }
 
 // FIXME: improve the test case for AES-256 key expansion.


### PR DESCRIPTION
1. Improve precision of `_mm_{rsqrt,rcp}_{ps,ss}`. Currently the precision of this part is guaranteed below 0.1% relative error.
2. Improve precision of `_mm_{sqrt,div}_{ps,ss}`. Currently the precision of this part is guaranteed below $10^{-6}$ % relative error.
3. Remove `SSE2NEON_PRECISE_DIV` as it is no longer being used.
    
Close #526.