### PR TITLE
Improve precision of _mm_{rsqrt,sqrt,rcp,div}_{ps,ss} conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ but SSE intrinsic `_mm_maddubs_epi16` has to be implemented with 13+ NEON instru
 
 Considering the balance between correctness and performance, `sse2neon` recognizes the following compile-time configurations:
 * `SSE2NEON_PRECISE_MINMAX`: Enable precise implementation of `_mm_min_{ps,pd}` and `_mm_max_{ps,pd}`. If you need consistent results such as NaN special cases, enable it.
-* `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
-* `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_DIV` (deprecated): Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_SQRT` (deprecated): Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_DP`: Enable precise implementation of `_mm_dp_pd`. When the conditional bit is not set, the corresponding multiplication would not be executed.
 
 The above are turned off by default, and you should define the corresponding macro(s) as `1` before including `sse2neon.h` if you need the precise implementations.

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1665,19 +1665,20 @@ FORCE_INLINE int64_t _mm_cvttss_si64(__m128 a)
 
 // Divide packed single-precision (32-bit) floating-point elements in a by
 // packed elements in b, and store the results in dst.
+// Due to ARMv7-A NEON's lack of a precise division intrinsic, we implement
+// division by multiplying a by b's reciprocal before using the Newton-Raphson
+// method to approximate the results.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_ps
 FORCE_INLINE __m128 _mm_div_ps(__m128 a, __m128 b)
 {
-#if defined(__aarch64__) && !SSE2NEON_PRECISE_DIV
+#if defined(__aarch64__)
     return vreinterpretq_m128_f32(
         vdivq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));
 #else
     float32x4_t recip = vrecpeq_f32(vreinterpretq_f32_m128(b));
     recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(b)));
-#if SSE2NEON_PRECISE_DIV
     // Additional Netwon-Raphson iteration for accuracy
     recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(b)));
-#endif
     return vreinterpretq_m128_f32(vmulq_f32(vreinterpretq_f32_m128(a), recip));
 #endif
 }
@@ -1686,6 +1687,8 @@ FORCE_INLINE __m128 _mm_div_ps(__m128 a, __m128 b)
 // lower single-precision (32-bit) floating-point element in b, store the result
 // in the lower element of dst, and copy the upper 3 packed elements from a to
 // the upper elements of dst.
+// Warning: ARMv7-A does not produce the same result compared to Intel and not
+// IEEE-compliant.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_div_ss
 FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
 {
@@ -2210,10 +2213,6 @@ FORCE_INLINE __m128 _mm_rcp_ps(__m128 in)
 {
     float32x4_t recip = vrecpeq_f32(vreinterpretq_f32_m128(in));
     recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(in)));
-#if SSE2NEON_PRECISE_DIV
-    // Additional Netwon-Raphson iteration for accuracy
-    recip = vmulq_f32(recip, vrecpsq_f32(recip, vreinterpretq_f32_m128(in)));
-#endif
     return vreinterpretq_m128_f32(recip);
 }
 
@@ -2234,13 +2233,8 @@ FORCE_INLINE __m128 _mm_rcp_ss(__m128 a)
 FORCE_INLINE __m128 _mm_rsqrt_ps(__m128 in)
 {
     float32x4_t out = vrsqrteq_f32(vreinterpretq_f32_m128(in));
-#if SSE2NEON_PRECISE_SQRT
-    // Additional Netwon-Raphson iteration for accuracy
     out = vmulq_f32(
         out, vrsqrtsq_f32(vmulq_f32(vreinterpretq_f32_m128(in), out), out));
-    out = vmulq_f32(
-        out, vrsqrtsq_f32(vmulq_f32(vreinterpretq_f32_m128(in), out), out));
-#endif
     return vreinterpretq_m128_f32(out);
 }
 
@@ -2550,10 +2544,15 @@ FORCE_INLINE void _mm_lfence(void)
 
 // Compute the square root of packed single-precision (32-bit) floating-point
 // elements in a, and store the results in dst.
+// Due to ARMv7-A NEON's lack of a precise square root intrinsic, we implement
+// square root by multiplying input in with its reciprocal square root before
+// using the Newton-Raphson method to approximate the results.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_sqrt_ps
 FORCE_INLINE __m128 _mm_sqrt_ps(__m128 in)
 {
-#if SSE2NEON_PRECISE_SQRT
+#if defined(__aarch64__)
+    return vreinterpretq_m128_f32(vsqrtq_f32(vreinterpretq_f32_m128(in)));
+#else
     float32x4_t recip = vrsqrteq_f32(vreinterpretq_f32_m128(in));
 
     // Test for vrsqrteq_f32(0) -> positive infinity case.
@@ -2564,22 +2563,16 @@ FORCE_INLINE __m128 _mm_sqrt_ps(__m128 in)
     recip = vreinterpretq_f32_u32(
         vandq_u32(vmvnq_u32(div_by_zero), vreinterpretq_u32_f32(recip)));
 
-    // Additional Netwon-Raphson iteration for accuracy
     recip = vmulq_f32(
         vrsqrtsq_f32(vmulq_f32(recip, recip), vreinterpretq_f32_m128(in)),
         recip);
+    // Additional Netwon-Raphson iteration for accuracy
     recip = vmulq_f32(
         vrsqrtsq_f32(vmulq_f32(recip, recip), vreinterpretq_f32_m128(in)),
         recip);
 
     // sqrt(s) = s * 1/sqrt(s)
     return vreinterpretq_m128_f32(vmulq_f32(vreinterpretq_f32_m128(in), recip));
-#elif defined(__aarch64__)
-    return vreinterpretq_m128_f32(vsqrtq_f32(vreinterpretq_f32_m128(in)));
-#else
-    float32x4_t recipsq = vrsqrteq_f32(vreinterpretq_f32_m128(in));
-    float32x4_t sq = vrecpeq_f32(recipsq);
-    return vreinterpretq_m128_f32(sq);
 #endif
 }
 

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -316,6 +316,27 @@ result_t validateFloatEpsilon(__m128 a,
     float df1 = fabsf(t[1] - f1);
     float df2 = fabsf(t[2] - f2);
     float df3 = fabsf(t[3] - f3);
+
+    // Due to floating-point error, subtracting floating-point number with NaN
+    // and zero value usually produces erroneous result. Therefore, we directly
+    // define the difference of two floating-point numbers to zero if both
+    // numbers are NaN or zero.
+    if ((std::isnan(t[0]) && std::isnan(f0)) || (t[0] == 0 && f0 == 0)) {
+        df0 = 0;
+    }
+
+    if ((std::isnan(t[1]) && std::isnan(f1)) || (t[1] == 0 && f1 == 0)) {
+        df1 = 0;
+    }
+
+    if ((std::isnan(t[2]) && std::isnan(f2)) || (t[2] == 0 && f2 == 0)) {
+        df2 = 0;
+    }
+
+    if ((std::isnan(t[3]) && std::isnan(f3)) || (t[3] == 0 && f3 == 0)) {
+        df3 = 0;
+    }
+
     ASSERT_RETURN(df0 < epsilon);
     ASSERT_RETURN(df1 < epsilon);
     ASSERT_RETURN(df2 < epsilon);

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2573,7 +2573,7 @@ result_t test_mm_rcp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ps(a);
-    return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
+    return validateFloatError(c, dx, dy, dz, dw, 0.001f);
 }
 
 result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2584,10 +2584,9 @@ result_t test_mm_rcp_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     float dy = _a[1];
     float dz = _a[2];
     float dw = _a[3];
-
     __m128 a = load_m128(_a);
     __m128 c = _mm_rcp_ss(a);
-    return validateFloatEpsilon(c, dx, dy, dz, dw, 300.0f);
+    return validateFloatError(c, dx, dy, dz, dw, 0.001f);
 }
 
 result_t test_mm_rsqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2602,9 +2601,9 @@ result_t test_mm_rsqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ps(a);
 
-    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_rsqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2619,9 +2618,9 @@ result_t test_mm_rsqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_rsqrt_ss(a);
 
-    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 1% compared
+    // Here, we ensure the error rate of "_mm_rsqrt_ps()" is under 0.1% compared
     // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+    return validateFloatError(c, f0, f1, f2, f3, 0.001f);
 }
 
 result_t test_mm_sad_pu8(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2844,9 +2843,15 @@ result_t test_mm_sqrt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ps(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 1% compared
-    // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+#if defined(__arm__) && !defined(__arm64__)
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" ARMv7-A implementation
+    // is under 10^-4% compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.0001f);
+#else
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 10^-6%
+    // compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.000001f);
+#endif
 }
 
 result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -2861,9 +2866,15 @@ result_t test_mm_sqrt_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     __m128 c = _mm_sqrt_ss(a);
 
-    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 1% compared
-    // to the C implementation.
-    return validateFloatError(c, f0, f1, f2, f3, 0.01f);
+#if defined(__arm__) && !defined(__arm64__)
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" ARMv7-A implementation
+    // is under 10^-4% compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.0001f);
+#else
+    // Here, we ensure the error rate of "_mm_sqrt_ps()" is under 10^-6%
+    // compared to the C implementation.
+    return validateFloatError(c, f0, f1, f2, f3, 0.000001f);
+#endif
 }
 
 result_t test_mm_store_ps(const SSE2NEONTestImpl &impl, uint32_t iter)


### PR DESCRIPTION
1. Improve precision of `_mm_{rsqrt,rcp}_{ps,ss}`. The precision of this part is guaranteed below 0.1% relative error.
2. Improve precision of `_mm_sqrt_{ps,ss}`. The precision of `_mm_sqrt_{ps,ss}` is guaranteed below $10^{-6}$% relative error on ARMv8-A and $10^{-4}$% relative error on ARMv7-A.
3. Add warnings of `_mm_sqrt_ps` and `_mm_div_ps` for ARMv7-A NEON implementation
as the results are not IEEE754-compliant due to lack of precise square
root and division intrinsic.
4. Add deprecation notice of `SSE2NEON_PRECISE_DIV` and `SSE2NEON_PRECISE_SQRT`
as accuracy has precedence of performance in `_mm_{rsqrt,sqrt,rcp,div}_{ps,ss}`.

Close #526.