### PR TITLE
Tweak MSVC ifdef guard for _BitScanForward64

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -113,7 +113,7 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #if (defined(_M_AMD64) || defined(__x86_64__)) || \
-    (defined(_M_ARM) || defined(__arm__))
+    (defined(_M_ARM64) || defined(__arm64__))
 #define SSE2NEON_HAS_BITSCAN64
 #endif
 #endif


### PR DESCRIPTION
ARM64 or AMD64 required for the 64-bit version of the _BitScanForward64 intrinsic.