### PR TITLE
Align result to SSE when input is 0.0f/-0.0f in _mm_rsqrt_{ps, ss}

### DIFF
--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -357,19 +357,23 @@ result_t validateFloatError(__m128 a,
     float df2 = fabsf((t[2] - f2) / f2);
     float df3 = fabsf((t[3] - f3) / f3);
 
-    if ((std::isnan(t[0]) && std::isnan(f0)) || (t[0] == 0 && f0 == 0)) {
+    if ((std::isnan(t[0]) && std::isnan(f0)) || (t[0] == 0 && f0 == 0) ||
+        (std::isinf(t[0]) && std::isinf(f0))) {
         df0 = 0;
     }
 
-    if ((std::isnan(t[1]) && std::isnan(f1)) || (t[1] == 0 && f1 == 0)) {
+    if ((std::isnan(t[1]) && std::isnan(f1)) || (t[1] == 0 && f1 == 0) ||
+        (std::isinf(t[1]) && std::isinf(f1))) {
         df1 = 0;
     }
 
-    if ((std::isnan(t[2]) && std::isnan(f2)) || (t[2] == 0 && f2 == 0)) {
+    if ((std::isnan(t[2]) && std::isnan(f2)) || (t[2] == 0 && f2 == 0) ||
+        (std::isinf(t[2]) && std::isinf(f2))) {
         df2 = 0;
     }
 
-    if ((std::isnan(t[3]) && std::isnan(f3)) || (t[3] == 0 && f3 == 0)) {
+    if ((std::isnan(t[3]) && std::isnan(f3)) || (t[3] == 0 && f3 == 0) ||
+        (std::isinf(t[3]) && std::isinf(f3))) {
         df3 = 0;
     }
 

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -78,6 +78,27 @@ public:
                 mTestFloatPointer1[2] = 1.0f / mTestFloatPointer1[2];
                 mTestFloatPointer1[3] = 1.0f / mTestFloatPointer1[3];
             }
+            if (test == it_mm_rcp_ps || test == it_mm_rcp_ss ||
+                test == it_mm_rsqrt_ps || test == it_mm_rsqrt_ss) {
+                if ((rand() & 3) == 0) {
+                    uint32_t r1 = rand() & 3;
+                    uint32_t r2 = rand() & 3;
+                    uint32_t r3 = rand() & 3;
+                    uint32_t r4 = rand() & 3;
+                    uint32_t r5 = rand() & 3;
+                    uint32_t r6 = rand() & 3;
+                    uint32_t r7 = rand() & 3;
+                    uint32_t r8 = rand() & 3;
+                    mTestFloatPointer1[r1] = 0.0f;
+                    mTestFloatPointer1[r2] = 0.0f;
+                    mTestFloatPointer1[r3] = 0.0f;
+                    mTestFloatPointer1[r4] = 0.0f;
+                    mTestFloatPointer1[r5] = -0.0f;
+                    mTestFloatPointer1[r6] = -0.0f;
+                    mTestFloatPointer1[r7] = -0.0f;
+                    mTestFloatPointer1[r8] = -0.0f;
+                }
+            }
             if (test == it_mm_cmpge_ps || test == it_mm_cmpge_ss ||
                 test == it_mm_cmple_ps || test == it_mm_cmple_ss ||
                 test == it_mm_cmpeq_ps || test == it_mm_cmpeq_ss) {


### PR DESCRIPTION
Align result to SSE when input is 0.0f/-0.0f in `_mm_rsqrt_{ps, ss}`.