### PR TITLE
Fix build for gcc-13 and 32 bit arm systems.

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -575,7 +575,7 @@ FORCE_INLINE uint32_t _mm_crc32_u8(uint32_t, uint8_t);
 
 // Older gcc does not define vld1q_u8_x4 type
 #if defined(__GNUC__) && !defined(__clang__) &&                        \
-    ((__GNUC__ <= 12 && defined(__arm__)) ||                           \
+    ((__GNUC__ <= 13 && defined(__arm__)) ||                           \
      (__GNUC__ == 10 && __GNUC_MINOR__ < 3 && defined(__aarch64__)) || \
      (__GNUC__ <= 9 && defined(__aarch64__)))
 FORCE_INLINE uint8x16x4_t _sse2neon_vld1q_u8_x4(const uint8_t *p)


### PR DESCRIPTION
   * gcc-13 still does not support vld1q_u8_x4 for 32 bit arm builds.