### PR TITLE
disambiguate vector type to avoid errors depending on lax conversion …

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5534,7 +5534,7 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
 FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
 {
 #if __has_builtin(__builtin_nontemporal_store)
-    __builtin_nontemporal_store(a, (float32x4_t *) p);
+    __builtin_nontemporal_store(a, (__m128d *) p);
 #elif defined(__aarch64__) || defined(_M_ARM64)
     vst1q_f64(p, vreinterpretq_f64_m128d(a));
 #else


### PR DESCRIPTION
…settings

Typecast explicitly to __m128d * to avoid compiler errors depending on platform and compiler, and the settings of -flax-vector-conversions or its different defaults

The test suite will fail to compile on AppleClang/aarch64 with at least AppleClang 14 and 15 if you add the compiler option -flax-vector-conversions to the makefile. There are projects that include sse2neon.h that have this option set.

Also, the option has differing defaults depending on compiler make and version, therefore it makes sense to not depend on it for the code to be compiled.

See discussions here: [llvm](https://reviews.llvm.org/D67678)  and here [gcc](https://gcc.gnu.org/bugzilla//show_bug.cgi?id=88698)