### PR TITLE
Add A32 support in CI

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -55,7 +55,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch_with_features: [{arch: armv7, feature: none}, {arch: aarch64, feature: none}, {arch: aarch64, feature: crypto+crc}]
+        arch_with_features: [
+          {arch: armv7, feature: none, arch_cflags: none},
+          {arch: aarch64, feature: none, arch_cflags: none},
+          {arch: aarch64, feature: crypto+crc, arch_cflags: none},
+          {arch: armv7, feature: none, arch_cflags: '-mcpu=cortex-a32 -mfpu=neon-fp-armv8'}
+        ]
         cxx_compiler: [g++-10, clang++-11]
     steps:
       - name: checkout code
@@ -69,6 +74,7 @@ jobs:
           distro: ubuntu20.04
           env: |
             CXX: ${{ matrix.cxx_compiler }}
+            ARCH_CFLAGS: ${{ matrix.arch_with_features.arch_cflags }}
           install: |
             apt-get update -q -y
             apt-get install -q -y "${{ matrix.cxx_compiler }}" make

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,24 @@ EXEC_WRAPPER = qemu-$(processor)
 endif
 
 # Follow platform-specific configurations
-ifeq ($(processor),$(filter $(processor),aarch64 arm64))
-    ARCH_CFLAGS = -march=armv8-a+fp+simd
-else ifeq ($(processor),$(filter $(processor),i386 x86_64))
-    ARCH_CFLAGS = -maes -mpclmul -mssse3 -msse4.2
-else ifeq ($(processor),$(filter $(processor),arm armv7 armv7l))
-    ARCH_CFLAGS = -mfpu=neon
-else
-    $(error Unsupported architecture)
+ARCH_CFLAGS ?=
+ARCH_CFLAGS_IS_SET =
+ifeq ($(ARCH_CFLAGS),)
+    ARCH_CFLAGS_IS_SET = true
+endif
+ifeq ($(ARCH_CFLAGS),none)
+    ARCH_CFLAGS_IS_SET = true
+endif
+ifdef ARCH_CFLAGS_IS_SET
+    ifeq ($(processor),$(filter $(processor),aarch64 arm64))
+        override ARCH_CFLAGS := -march=armv8-a+fp+simd
+    else ifeq ($(processor),$(filter $(processor),i386 x86_64))
+        override ARCH_CFLAGS := -maes -mpclmul -mssse3 -msse4.2
+    else ifeq ($(processor),$(filter $(processor),arm armv7 armv7l))
+        override ARCH_CFLAGS := -mfpu=neon
+    else
+        $(error Unsupported architecture)
+    endif
 endif
 
 FEATURE ?=

--- a/README.md
+++ b/README.md
@@ -117,14 +117,36 @@ The following command enable `crypto` and `crc` features in the tests.
 $ make FEATURE=crypto+crc check
 ```
 
-You can specify GNU toolchain for cross compilation as well.
+For running check on certain CPU, setting the mode of FPU, etc.,
+you can also assign the desired options with `ARCH_CFLAGS` command.
+If `none` is assigned, the command acts as same as calling `make check`.
+For instance, to run tests on Cortex-A53 with enabling ARM VFPv4 extension and NEON:
+```
+$ make ARCH_CFLAGS="-mcpu=cortex-a53 -mfpu=neon-vfpv4" check
+```
+
+### Running tests on hosts other than ARM platform
+
+For running tests on hosts other than ARM platform,
+you can specify GNU toolchain for cross compilation with `CROSS_COMPILE` command.
 [QEMU](https://www.qemu.org/) should be installed in advance.
+
+For ARMv8-A running in 64-bit mode type:
 ```shell
 $ make CROSS_COMPILE=aarch64-linux-gnu- check # ARMv8-A
 ```
-or
+
+For ARMv7-A type:
 ```shell
 $ make CROSS_COMPILE=arm-linux-gnueabihf- check # ARMv7-A
+```
+
+For ARMv8-A running in 32-bit mode (A32 instruction set) type:
+```shell
+$ make \
+  CROSS_COMPILE=arm-linux-gnueabihf- \
+  ARCH_CFLAGS="-mcpu=cortex-a32 -mfpu=neon-fp-armv8" \
+  check 
 ```
 
 Check the details via [Test Suite for SSE2NEON](tests/README.md).


### PR DESCRIPTION
Add A32 support in CI.

For @jonathanhue, if possible, kindly leave some suggestions as I have little experience on A32 binary running on Armv8-A.