### PR TITLE
Fix _mm_test_mix_ones_zeros and _mm_testnzc_si128

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -7592,14 +7592,10 @@ FORCE_INLINE int _mm_test_all_zeros(__m128i a, __m128i mask)
 // zero, otherwise set CF to 0. Return 1 if both the ZF and CF values are zero,
 // otherwise return 0.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_test_mix_ones_zero
+// Note: Argument names may be wrong in the Intel intrinsics guide.
 FORCE_INLINE int _mm_test_mix_ones_zeros(__m128i a, __m128i mask)
 {
-    uint64x2_t zf =
-        vandq_u64(vreinterpretq_u64_m128i(mask), vreinterpretq_u64_m128i(a));
-    uint64x2_t cf =
-        vbicq_u64(vreinterpretq_u64_m128i(mask), vreinterpretq_u64_m128i(a));
-    uint64x2_t result = vandq_u64(zf, cf);
-    return !(vgetq_lane_u64(result, 0) | vgetq_lane_u64(result, 1));
+    return !(_mm_testz_si128(a, mask) | _mm_testc_si128(a, mask));
 }
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and b,

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -7593,10 +7593,7 @@ FORCE_INLINE int _mm_test_all_zeros(__m128i a, __m128i mask)
 // otherwise return 0.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_test_mix_ones_zero
 // Note: Argument names may be wrong in the Intel intrinsics guide.
-FORCE_INLINE int _mm_test_mix_ones_zeros(__m128i a, __m128i mask)
-{
-    return !(_mm_testz_si128(a, mask) | _mm_testc_si128(a, mask));
-}
+#define _mm_test_mix_ones_zeros(a, b) _mm_testnzc_si128(a, b)
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and b,
 // and set ZF to 1 if the result is zero, otherwise set ZF to 0. Compute the
@@ -7616,7 +7613,10 @@ FORCE_INLINE int _mm_testc_si128(__m128i a, __m128i b)
 // otherwise set CF to 0. Return 1 if both the ZF and CF values are zero,
 // otherwise return 0.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_testnzc_si128
-#define _mm_testnzc_si128(a, b) _mm_test_mix_ones_zeros(a, b)
+FORCE_INLINE int _mm_testnzc_si128(__m128i a, __m128i b)
+{
+    return !(_mm_test_all_zeros(a, b) | _mm_testc_si128(a, b));
+}
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and b,
 // and set ZF to 1 if the result is zero, otherwise set ZF to 0. Compute the

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -7593,7 +7593,7 @@ FORCE_INLINE int _mm_test_all_zeros(__m128i a, __m128i mask)
 // otherwise return 0.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_test_mix_ones_zero
 // Note: Argument names may be wrong in the Intel intrinsics guide.
-#define _mm_test_mix_ones_zeros(a, b) _mm_testnzc_si128(a, b)
+#define _mm_test_mix_ones_zeros(a, mask) _mm_testnzc_si128(a, mask)
 
 // Compute the bitwise AND of 128 bits (representing integer data) in a and b,
 // and set ZF to 1 if the result is zero, otherwise set ZF to 0. Compute the

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -9228,13 +9228,13 @@ result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl,
     __m128i a = load_m128i(_a);
     __m128i mask = load_m128i(_mask);
 
-    int32_t has_ones = 0;
-    int32_t has_zeros = 0;
-    for (int i = 0; i < 4; i++) {
-        has_ones |= _a[i] & _mask[i];
-        has_zeros |= ~_a[i] & _mask[i];
+    int32_t ZF = 1;
+    int32_t CF = 1;
+    for(int i = 0; i < 4; i++) {
+        ZF &= ((_a[i] & _mask[i]) == 0);
+        CF &= ((~_a[i] & _mask[i]) == 0);
     }
-    int32_t result = ((has_ones != 0) & (has_zeros != 0));
+    int32_t result = (ZF == 0 && CF == 0);
 
     int32_t ret = _mm_test_mix_ones_zeros(a, mask);
     return result == ret ? TEST_SUCCESS : TEST_FAIL;

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -9230,7 +9230,7 @@ result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl,
 
     int32_t ZF = 1;
     int32_t CF = 1;
-    for(int i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         ZF &= ((_a[i] & _mask[i]) == 0);
         CF &= ((~_a[i] & _mask[i]) == 0);
     }

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -9237,7 +9237,7 @@ result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl,
     int32_t result = ((has_ones != 0) & (has_zeros != 0));
 
     int32_t ret = _mm_test_mix_ones_zeros(a, mask);
-    return result == ret ? 1 : 0;
+    return result == ret ? TEST_SUCCESS : TEST_FAIL;
 }
 
 result_t test_mm_testc_si128(const SSE2NEONTestImpl &impl, uint32_t iter)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -9228,15 +9228,16 @@ result_t test_mm_test_mix_ones_zeros(const SSE2NEONTestImpl &impl,
     __m128i a = load_m128i(_a);
     __m128i mask = load_m128i(_mask);
 
-    int32_t d0 = !((_a[0]) & _mask[0]) & !((!_a[0]) & _mask[0]);
-    int32_t d1 = !((_a[1]) & _mask[1]) & !((!_a[1]) & _mask[1]);
-    int32_t d2 = !((_a[2]) & _mask[2]) & !((!_a[2]) & _mask[2]);
-    int32_t d3 = !((_a[3]) & _mask[3]) & !((!_a[3]) & _mask[3]);
-    int32_t result = ((d0 & d1 & d2 & d3) == 0) ? 1 : 0;
+    int32_t has_ones = 0;
+    int32_t has_zeros = 0;
+    for (int i = 0; i < 4; i++) {
+        has_ones |= _a[i] & _mask[i];
+        has_zeros |= ~_a[i] & _mask[i];
+    }
+    int32_t result = ((has_ones != 0) & (has_zeros != 0));
 
     int32_t ret = _mm_test_mix_ones_zeros(a, mask);
-
-    return result == ret ? TEST_SUCCESS : TEST_FAIL;
+    return result == ret ? 1 : 0;
 }
 
 result_t test_mm_testc_si128(const SSE2NEONTestImpl &impl, uint32_t iter)


### PR DESCRIPTION
Bug: `_mm_test_mix_ones_zeros` always returned true.
The function wasn't reducing `zf` and `cf` to a bool before combining them.

The fix proposed here isn't the most efficient, but at least it is correct. 

` _mm_testnzc_si128` is an alias for `_mm_test_mix_ones_zeros`.


Note(s):
The arguments are named incorrectly in the `_mm_test_mix_ones_zeros` documentation[0].
The second argument is the mask, as per the behavior of `_mm_test_mix_ones_zeros` with gcc and clang.
This naming error seems to have propagated through both gcc[1] and llvm[2] headers but not to rust[3] headers or sse2neon[4].

[0] https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=ptest&techs=SSE_ALL&ig_expand=6902
[1] https://github.com/gcc-mirror/gcc/blob/27ce74fa23c93c1189c301993cd19ea766e6bdb5/gcc/config/i386/smmintrin.h#L94
[2] https://github.com/llvm/llvm-project/blob/70535f5e609f747c28cfef699eefb84581b0aac0/clang/lib/Headers/smmintrin.h#L1130
[3] https://github.com/rust-lang/stdarch/blob/f4528dd6e85d97bb802240d7cd048b6e1bf72540/crates/core_arch/src/x86/sse41.rs#L1149
[4] https://github.com/DLTcollab/sse2neon/blob/243e90f654193c97a691b1a53213d091e02eb631/sse2neon.h#L7595