### PR TITLE
Fix Clang showing incorrect GCC version warning

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -104,7 +104,7 @@
 #pragma message("Macro name collisions may happen with unsupported compilers.")
 #endif
 
-#if defined(__GNUC__) && __GNUC__ < 10
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 10
 #warning "GCC versions earlier than 10 are not supported."
 #endif
 


### PR DESCRIPTION
Clang also defines `__GNUC__` and even in recent Clang versions like 15 this value is 4.