### PR TITLE
Restore options for precision of div/rcp/sqrt/rsqrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ As a result, additional treatments should be applied to ensure consistency betwe
 Though floating-point operations in NEON use the IEEE single-precision format, NEON does not fully comply to the IEEE standard when inputs or results are denormal or NaN values for minimizing power consumption as well as maximizing performance.
 Considering the balance between correctness and performance, `sse2neon` recognizes the following compile-time configurations:
 * `SSE2NEON_PRECISE_MINMAX`: Enable precise implementation of `_mm_min_{ps,pd}` and `_mm_max_{ps,pd}`. If you need consistent results such as handling with NaN values, enable it.
-* `SSE2NEON_PRECISE_DIV` (deprecated): Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
-* `SSE2NEON_PRECISE_SQRT` (deprecated): Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_DP`: Enable precise implementation of `_mm_dp_pd`. When the conditional bit is not set, the corresponding multiplication would not be executed.
 
 The above are turned off by default, and you should define the corresponding macro(s) as `1` before including `sse2neon.h` if you need the precise implementations.


### PR DESCRIPTION
This restores support for SSE2NEON_PRECISE_DIV and SSE2NEON_PRECISE_SQRT with the same level of precision that they had before deprecation in #580.

That changed enabled higher precision by default, but not as high as was possible with the options before. The options were originally added to make Embree and Blender work correctly on Apple Silicion, and tested to need exactly this level of precision.

---

It would be helpful for Blender not to have to maintain either a patched sse2neon or work with different tolerances on x86 and ARM.