### PR TITLE
Fix undefined `_mm_malloc` and `_mm_free` when building with LLVM/MinGW.

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -120,10 +120,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#if defined(_WIN32)
-/* Definitions for _mm_{malloc,free} are provided by <malloc.h>
- * from both MinGW-w64 and MSVC.
- */
+#if defined(_WIN32) && !defined(__MINGW32__)
+/* Definitions for _mm_{malloc,free} are provided by <malloc.h> from MSVC. */
 #define SSE2NEON_ALLOC_DEFINED
 #endif
 
@@ -1767,7 +1765,11 @@ FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
 #if !defined(SSE2NEON_ALLOC_DEFINED)
 FORCE_INLINE void _mm_free(void *addr)
 {
+#if defined(_WIN32)
+    _aligned_free(addr);
+#else
     free(addr);
+#endif
 }
 #endif
 
@@ -1955,8 +1957,14 @@ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
         return malloc(size);
     if (align == 2 || (sizeof(void *) == 8 && align == 4))
         align = sizeof(void *);
+#if defined(_WIN32)
+    ptr = _aligned_malloc(size, align);
+    if (ptr)
+        return ptr;
+#else
     if (!posix_memalign(&ptr, align, size))
         return ptr;
+#endif
     return NULL;
 }
 #endif


### PR DESCRIPTION
MinGW define  `_mm_malloc` and `_mm_free` only for x86, but not for ARM.

https://github.com/mingw-w64/mingw-w64/blob/7c9cfe6708cafc83c14a2654308b2db62b126eae/mingw-w64-headers/crt/malloc.h#L82-L85