### PR TITLE
fix: Fix strict-aliasing errors

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2444,7 +2444,7 @@ FORCE_INLINE __m128 _mm_set_ps1(float _w)
 // the following flags: _MM_ROUND_NEAREST, _MM_ROUND_DOWN, _MM_ROUND_UP,
 // _MM_ROUND_TOWARD_ZERO
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_SET_ROUNDING_MODE
-FORCE_INLINE void _MM_SET_ROUNDING_MODE(int rounding)
+FORCE_INLINE_OPTNONE void _MM_SET_ROUNDING_MODE(int rounding)
 {
     union {
         fpcr_bitfield field;
@@ -4158,7 +4158,7 @@ FORCE_INLINE __m128i _mm_cvttpd_epi32(__m128d a)
 // Convert packed double-precision (64-bit) floating-point elements in a to
 // packed 32-bit integers with truncation, and store the results in dst.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttpd_pi32
-FORCE_INLINE __m64 _mm_cvttpd_pi32(__m128d a)
+FORCE_INLINE_OPTNONE __m64 _mm_cvttpd_pi32(__m128d a)
 {
     double a0 = ((double *) &a)[0];
     double a1 = ((double *) &a)[1];
@@ -9219,7 +9219,7 @@ FORCE_INLINE int64_t _mm_popcnt_u64(uint64_t a)
 #endif
 }
 
-FORCE_INLINE void _sse2neon_mm_set_denormals_zero_mode(unsigned int flag)
+FORCE_INLINE_OPTNONE void _sse2neon_mm_set_denormals_zero_mode(unsigned int flag)
 {
     // AArch32 Advanced SIMD arithmetic always uses the Flush-to-zero setting,
     // regardless of the value of the FZ bit.

--- a/tests/common.h
+++ b/tests/common.h
@@ -64,8 +64,6 @@ enum result_t {
 };
 extern int32_t NaN;
 extern int64_t NaN64;
-#define ALL_BIT_1_32 (*(float *) &NaN)
-#define ALL_BIT_1_64 (*(double *) &NaN64)
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma push_macro("OPTNONE")
@@ -76,6 +74,34 @@ extern int64_t NaN64;
 #else
 #define OPTNONE
 #endif
+
+#include <string.h>
+static inline double sse2neon_tool_recast_f64(uint64_t u64)
+{
+    double f64;
+    memcpy(&f64, &u64, sizeof(uint64_t));
+    return f64;
+}
+static inline int64_t sse2neon_tool_recast_i64(double f64)
+{
+    int64_t i64;
+    memcpy(&i64, &f64, sizeof(int64_t));
+    return i64;
+}
+static inline float sse2neon_tool_recast_f32(uint32_t u32)
+{
+    float f32;
+    memcpy(&f32, &u32, sizeof(uint32_t));
+    return f32;
+}
+static inline float sse2neon_tool_recast_f32(int32_t i32)
+{
+    float f32;
+    memcpy(&f32, &i32, sizeof(int32_t));
+    return f32;
+}
+#define ALL_BIT_1_32 sse2neon_tool_recast_f32(UINT32_MAX)
+#define ALL_BIT_1_64 sse2neon_tool_recast_f64(UINT64_MAX)
 
 template <typename T>
 result_t validate128(T a, T b)

--- a/tests/common.h
+++ b/tests/common.h
@@ -67,6 +67,16 @@ extern int64_t NaN64;
 #define ALL_BIT_1_32 (*(float *) &NaN)
 #define ALL_BIT_1_64 (*(double *) &NaN64)
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma push_macro("OPTNONE")
+#define OPTNONE __attribute__((optimize("O0")))
+#elif defined(__clang__)
+#pragma push_macro("OPTNONE")
+#define OPTNONE __attribute__((optnone))
+#else
+#define OPTNONE
+#endif
+
 template <typename T>
 result_t validate128(T a, T b)
 {

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -2751,7 +2751,7 @@ result_t test_mm_set_ps1(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateFloat(ret, a, a, a, a);
 }
 
-result_t test_mm_set_rounding_mode(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_set_rounding_mode(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     result_t res_toward_zero, res_to_neg_inf, res_to_pos_inf, res_nearest;
@@ -4444,7 +4444,7 @@ result_t test_mm_cvtepi32_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateFloat(ret, trun[0], trun[1], trun[2], trun[3]);
 }
 
-result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     int32_t d[2] = {};
@@ -8425,7 +8425,7 @@ result_t test_mm_cvtepu8_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
     MM_DP_PD_TEST_CASE_WITH(0x22);   \
     MM_DP_PD_TEST_CASE_WITH(0x23);
 
-result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     GENERATE_MM_DP_PD_TEST_CASES
     return TEST_SUCCESS;
@@ -8460,7 +8460,7 @@ result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     MM_DP_PS_TEST_CASE_WITH(0x23);   \
     MM_DP_PS_TEST_CASE_WITH(0xB5);
 
-result_t test_mm_dp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_dp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     GENERATE_MM_DP_PS_TEST_CASES
     return TEST_SUCCESS;
@@ -11819,8 +11819,8 @@ result_t test_mm_popcnt_u64(const SSE2NEONTestImpl &impl, uint32_t iter)
     return TEST_SUCCESS;
 }
 
-result_t test_mm_set_denormals_zero_mode(const SSE2NEONTestImpl &impl,
-                                         uint32_t iter)
+OPTNONE result_t test_mm_set_denormals_zero_mode(const SSE2NEONTestImpl &impl,
+                                                 uint32_t iter)
 {
     result_t res_set_denormals_zero_on, res_set_denormals_zero_off;
     float factor = 2;

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -431,7 +431,7 @@ template <class T>
 __m128i load_m128i(const T *p)
 {
     __m128 a = _mm_loadu_ps((const float *) p);
-    __m128i ia = *(const __m128i *) &a;
+    __m128i ia = _mm_castps_si128(a);
     return ia;
 }
 
@@ -461,7 +461,7 @@ result_t do_mm_store_ps(float *p, float x, float y, float z, float w)
 result_t do_mm_store_ps(int32_t *p, int32_t x, int32_t y, int32_t z, int32_t w)
 {
     __m128i a = _mm_set_epi32(x, y, z, w);
-    _mm_store_ps((float *) p, *(const __m128 *) &a);
+    _mm_store_ps((float *) p, _mm_castsi128_ps(a));
     ASSERT_RETURN(p[0] == w);
     ASSERT_RETURN(p[1] == z);
     ASSERT_RETURN(p[2] == y);
@@ -850,7 +850,7 @@ result_t test_mm_and_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     r[2] = ia[2] & ib[2];
     r[3] = ia[3] & ib[3];
     __m128i ret = do_mm_set_epi32(r[3], r[2], r[1], r[0]);
-    result_t res = VALIDATE_INT32_M128(*(const __m128i *) &c, r);
+    result_t res = VALIDATE_INT32_M128(_mm_castps_si128(c), r);
     if (res) {
         res = VALIDATE_INT32_M128(ret, r);
     }
@@ -879,7 +879,7 @@ result_t test_mm_andnot_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     r[3] = ~ia[3] & ib[3];
     __m128i ret = do_mm_set_epi32(r[3], r[2], r[1], r[0]);
     result_t res = TEST_FAIL;
-    res = VALIDATE_INT32_M128(*(const __m128i *) &c, r);
+    res = VALIDATE_INT32_M128(_mm_castps_si128(c), r);
     if (res) {
         res = VALIDATE_INT32_M128(ret, r);
     }
@@ -938,7 +938,7 @@ result_t test_mm_cmpeq_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] == _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmpeq_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -973,7 +973,7 @@ result_t test_mm_cmpge_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] >= _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmpge_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -1008,7 +1008,7 @@ result_t test_mm_cmpgt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] > _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmpgt_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -1043,7 +1043,7 @@ result_t test_mm_cmple_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] <= _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmple_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -1078,7 +1078,7 @@ result_t test_mm_cmplt_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] < _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmplt_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -1114,7 +1114,7 @@ result_t test_mm_cmpneq_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     result[3] = _a[3] != _b[3] ? -1 : 0;
 
     __m128 ret = _mm_cmpneq_ps(a, b);
-    __m128i iret = *(const __m128i *) &ret;
+    __m128i iret = _mm_castps_si128(ret);
     return VALIDATE_INT32_M128(iret, result);
 }
 
@@ -2519,7 +2519,7 @@ result_t test_mm_or_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     r[2] = ia[2] | ib[2];
     r[3] = ia[3] | ib[3];
     __m128i ret = do_mm_set_epi32(r[3], r[2], r[1], r[0]);
-    result_t res = VALIDATE_INT32_M128(*(const __m128i *) &c, r);
+    result_t res = VALIDATE_INT32_M128(_mm_castps_si128(c), r);
     if (res) {
         res = VALIDATE_INT32_M128(ret, r);
     }
@@ -2751,7 +2751,8 @@ result_t test_mm_set_ps1(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateFloat(ret, a, a, a, a);
 }
 
-OPTNONE result_t test_mm_set_rounding_mode(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_set_rounding_mode(const SSE2NEONTestImpl &impl,
+                                           uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     result_t res_toward_zero, res_to_neg_inf, res_to_pos_inf, res_nearest;
@@ -2980,7 +2981,7 @@ result_t test_mm_store_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     int32_t z = impl.mTestInts[iter + 2];
     int32_t w = impl.mTestInts[iter + 3];
     __m128i a = _mm_set_epi32(x, y, z, w);
-    _mm_store_ps((float *) p, *(const __m128 *) &a);
+    _mm_store_ps((float *) p, _mm_castsi128_ps(a));
     ASSERT_RETURN(p[0] == w);
     ASSERT_RETURN(p[1] == z);
     ASSERT_RETURN(p[2] == y);
@@ -3255,18 +3256,16 @@ result_t test_mm_xor_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int32_t *_a = (const int32_t *) impl.mTestFloatPointer1;
     const int32_t *_b = (const int32_t *) impl.mTestFloatPointer2;
-
-    int32_t d0 = _a[0] ^ _b[0];
-    int32_t d1 = _a[1] ^ _b[1];
-    int32_t d2 = _a[2] ^ _b[2];
-    int32_t d3 = _a[3] ^ _b[3];
+    float d0 = sse2neon_tool_recast_f32(_a[0] ^ _b[0]);
+    float d1 = sse2neon_tool_recast_f32(_a[1] ^ _b[1]);
+    float d2 = sse2neon_tool_recast_f32(_a[2] ^ _b[2]);
+    float d3 = sse2neon_tool_recast_f32(_a[3] ^ _b[3]);
 
     __m128 a = load_m128(_a);
     __m128 b = load_m128(_b);
     __m128 c = _mm_xor_ps(a, b);
 
-    return validateFloat(c, *((float *) &d0), *((float *) &d1),
-                         *((float *) &d2), *((float *) &d3));
+    return validateFloat(c, d0, d1, d2, d3);
 }
 
 /* SSE2 */
@@ -3552,15 +3551,14 @@ result_t test_mm_and_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestFloatPointer1;
     const int64_t *_b = (const int64_t *) impl.mTestFloatPointer2;
-
-    int64_t d0 = _a[0] & _b[0];
-    int64_t d1 = _a[1] & _b[1];
+    double d0 = sse2neon_tool_recast_f64(_a[0] & _b[0]);
+    double d1 = sse2neon_tool_recast_f64(_a[1] & _b[1]);
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_and_pd(a, b);
 
-    return validateDouble(c, *((double *) &d0), *((double *) &d1));
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_and_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -3569,8 +3567,8 @@ result_t test_mm_and_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_b = impl.mTestIntPointer2;
     __m128i a = load_m128i(_a);
     __m128i b = load_m128i(_b);
-    __m128 fc = _mm_and_ps(*(const __m128 *) &a, *(const __m128 *) &b);
-    __m128i c = *(const __m128i *) &fc;
+    __m128 fc = _mm_and_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b));
+    __m128i c = _mm_castps_si128(fc);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
     const uint32_t *ib = (const uint32_t *) &b;
@@ -3603,7 +3601,7 @@ result_t test_mm_andnot_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     const uint64_t *ib = (const uint64_t *) &b;
     uint64_t r0 = ~ia[0] & ib[0];
     uint64_t r1 = ~ia[1] & ib[1];
-    return validateUInt64(*(const __m128i *) &c, r0, r1);
+    return validateUInt64(_mm_castpd_si128(c), r0, r1);
 }
 
 result_t test_mm_andnot_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -3612,8 +3610,8 @@ result_t test_mm_andnot_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_b = impl.mTestIntPointer2;
     __m128i a = load_m128i(_a);
     __m128i b = load_m128i(_b);
-    __m128 fc = _mm_andnot_ps(*(const __m128 *) &a, *(const __m128 *) &b);
-    __m128i c = *(const __m128i *) &fc;
+    __m128 fc = _mm_andnot_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b));
+    __m128i c = _mm_castps_si128(fc);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
     const uint32_t *ib = (const uint32_t *) &b;
@@ -3832,55 +3830,55 @@ result_t test_mm_cmpeq_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] == _b[0]) ? 0xffffffffffffffff : 0;
-    uint64_t d1 = (_a[1] == _b[1]) ? 0xffffffffffffffff : 0;
+    double d0 = (_a[0] == _b[0]) ? sse2neon_tool_recast_f64(UINT64_MAX) : 0;
+    double d1 = (_a[1] == _b[1]) ? sse2neon_tool_recast_f64(UINT64_MAX) : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpeq_pd(a, b);
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpeq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    const uint64_t d0 = (_a[0] == _b[0]) ? ~UINT64_C(0) : 0;
-    const uint64_t d1 = ((const uint64_t *) _a)[1];
+    double d0 = (_a[0] == _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpeq_sd(a, b);
 
-    return validateDouble(c, *(const double *) &d0, *(const double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpge_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = (_a[1] >= _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = (_a[0] >= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = (_a[1] >= _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpge_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpge_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = (_a[0] >= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpge_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpgt_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -3954,56 +3952,56 @@ result_t test_mm_cmpgt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = (_a[1] > _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = (_a[0] > _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = (_a[1] > _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpgt_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpgt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = (_a[0] > _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpgt_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmple_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = (_a[1] <= _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = (_a[0] <= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = (_a[1] <= _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmple_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmple_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = (_a[0] <= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmple_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmplt_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -4076,171 +4074,168 @@ result_t test_mm_cmplt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-
-    int64_t f0 = (_a[0] < _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    int64_t f1 = (_a[1] < _b[1]) ? ~UINT64_C(0) : UINT64_C(0);
+    double d0 = (_a[0] < _b[0]) ? ALL_BIT_1_64 : UINT64_C(0);
+    double d1 = (_a[1] < _b[1]) ? ALL_BIT_1_64 : UINT64_C(0);
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmplt_pd(a, b);
 
-    return validateDouble(c, *(double *) &f0, *(double *) &f1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmplt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = (_a[0] < _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = (_a[0] < _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmplt_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpneq_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-
-    int64_t f0 = (_a[0] != _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    int64_t f1 = (_a[1] != _b[1]) ? ~UINT64_C(0) : UINT64_C(0);
+    double d0 = (_a[0] != _b[0]) ? ALL_BIT_1_64 : UINT64_C(0);
+    double d1 = (_a[1] != _b[1]) ? ALL_BIT_1_64 : UINT64_C(0);
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpneq_pd(a, b);
 
-    return validateDouble(c, *(double *) &f0, *(double *) &f1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpneq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-
-    int64_t f0 = (_a[0] != _b[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    int64_t f1 = ((int64_t *) _a)[1];
+    double d0 = (_a[0] != _b[0]) ? ALL_BIT_1_64 : UINT64_C(0);
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpneq_sd(a, b);
 
-    return validateDouble(c, *(double *) &f0, *(double *) &f1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnge_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = !(_a[1] >= _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = !(_a[0] >= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = !(_a[1] >= _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnge_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnge_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] >= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = !(_a[0] >= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnge_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpngt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = !(_a[1] > _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = !(_a[0] > _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = !(_a[1] > _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpngt_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpngt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] > _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = !(_a[0] > _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpngt_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnle_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = !(_a[1] <= _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = !(_a[0] <= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = !(_a[1] <= _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnle_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnle_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] <= _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = !(_a[0] <= _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnle_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnlt_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     const double *_b = (const double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] < _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = !(_a[1] < _b[1]) ? ~UINT64_C(0) : 0;
+    double d0 = !(_a[0] < _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = !(_a[1] < _b[1]) ? ALL_BIT_1_64 : 0;
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnlt_pd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpnlt_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     double *_a = (double *) impl.mTestFloatPointer1;
     double *_b = (double *) impl.mTestFloatPointer2;
-    uint64_t d0 = !(_a[0] < _b[0]) ? ~UINT64_C(0) : 0;
-    uint64_t d1 = ((uint64_t *) _a)[1];
+    double d0 = !(_a[0] < _b[0]) ? ALL_BIT_1_64 : 0;
+    double d1 = _a[1];
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_cmpnlt_sd(a, b);
 
-    return validateDouble(c, *(double *) &d0, *(double *) &d1);
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_cmpord_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -4444,7 +4439,8 @@ result_t test_mm_cvtepi32_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateFloat(ret, trun[0], trun[1], trun[2], trun[3]);
 }
 
-OPTNONE result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl,
+                                     uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     int32_t d[2] = {};
@@ -5504,15 +5500,14 @@ result_t test_mm_or_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestFloatPointer1;
     const int64_t *_b = (const int64_t *) impl.mTestFloatPointer2;
-
-    int64_t d0 = _a[0] | _b[0];
-    int64_t d1 = _a[1] | _b[1];
+    double d0 = sse2neon_tool_recast_f64(_a[0] | _b[0]);
+    double d1 = sse2neon_tool_recast_f64(_a[1] | _b[1]);
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_or_pd(a, b);
 
-    return validateDouble(c, *((double *) &d0), *((double *) &d1));
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_or_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -5521,8 +5516,8 @@ result_t test_mm_or_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
     const int32_t *_b = impl.mTestIntPointer2;
     __m128i a = load_m128i(_a);
     __m128i b = load_m128i(_b);
-    __m128 fc = _mm_or_ps(*(const __m128 *) &a, *(const __m128 *) &b);
-    __m128i c = *(const __m128i *) &fc;
+    __m128 fc = _mm_or_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b));
+    __m128i c = _mm_castps_si128(fc);
     // now for the assertion...
     const uint32_t *ia = (const uint32_t *) &a;
     const uint32_t *ib = (const uint32_t *) &b;
@@ -7092,15 +7087,14 @@ result_t test_mm_xor_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const int64_t *_a = (const int64_t *) impl.mTestFloatPointer1;
     const int64_t *_b = (const int64_t *) impl.mTestFloatPointer2;
-
-    int64_t d0 = _a[0] ^ _b[0];
-    int64_t d1 = _a[1] ^ _b[1];
+    double d0 = sse2neon_tool_recast_f64(_a[0] ^ _b[0]);
+    double d1 = sse2neon_tool_recast_f64(_a[1] ^ _b[1]);
 
     __m128d a = load_m128d(_a);
     __m128d b = load_m128d(_b);
     __m128d c = _mm_xor_pd(a, b);
 
-    return validateDouble(c, *((double *) &d0), *((double *) &d1));
+    return validateDouble(c, d0, d1);
 }
 
 result_t test_mm_xor_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
@@ -8095,7 +8089,8 @@ result_t test_mm_blendv_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     for (int i = 0; i < 2; i++) {
         // signed shift right would return a result which is either all 1's from
         // negative numbers or all 0's from positive numbers
-        if ((*(const int64_t *) (_mask + i)) >> 63) {
+        int64_t m = sse2neon_tool_recast_i64(_mask[i]);
+        if (m >> 63) {
             _c[i] = _b[i];
         } else {
             _c[i] = _a[i];


### PR DESCRIPTION
Casting vector registers to a pointer or accessing the address of a
variable and then casting it to a different pointer type would
violate strict aliasing rules, potentially causing strict aliasing
errors.

`sse2neon_recast_u64_f64` and `sse2neon_recast_f64_s64` are introduced
to solve this error.

closes #635 #639