### PR TITLE
Allow optimization and use fesetround(), fegetround()

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ $ make \
 
 Check the details via [Test Suite for SSE2NEON](tests/README.md).
 
+### Optimization
+
+Misbehavior may exist when turning on optimization options. Developers should be aware of possible errors.
+
 ## Adoptions
 Here is a partial list of open source projects that have adopted `sse2neon` for Arm/Aarch64 support.
 * [Aaru Data Preservation Suite](https://www.aaru.app/) is a fully-featured software package to preserve all storage media from the very old to the cutting edge, as well as to give detailed information about any supported image file (whether from Aaru or not) and to extract the files from those images.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,12 @@ Check the details via [Test Suite for SSE2NEON](tests/README.md).
 
 ### Optimization
 
-Misbehavior may exist when turning on optimization options. Developers should be aware of possible errors.
+The SSE2NEON project is designed with performance-sensitive scenarios in mind, and as such, optimization options (e.g. `O1`, `O2`) can lead to misbehavior under specific circumstances. For example, frequent changes to the rounding mode or repeated calls to `_MM_SET_DENORMALS_ZERO_MODE()` may introduce unintended behavior.
+
+Enforcing no optimizations for specific intrinsics could solve these boundary cases but may negatively impact general performance. Therefore, we have decided to prioritize performance and shift the responsibility for handling such edge cases to developers.
+
+It is important to be aware of these potential pitfalls when enabling optimizations and ensure that your code accounts for these scenarios if necessary.
+
 
 ## Adoptions
 Here is a partial list of open source projects that have adopted `sse2neon` for Arm/Aarch64 support.

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -4793,7 +4793,8 @@ result_t test_mm_cvttpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateInt32(ret, d0, d1, 0, 0);
 }
 
-OPTNONE result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl,
+                                     uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
 

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -4485,7 +4485,7 @@ OPTNONE result_t test_mm_cvtpd_epi32(const SSE2NEONTestImpl &impl,
     return validateInt32(ret, d[0], d[1], 0, 0);
 }
 
-result_t test_mm_cvtpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_cvtpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
     int32_t d[2] = {};
@@ -4793,7 +4793,7 @@ result_t test_mm_cvttpd_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateInt32(ret, d0, d1, 0, 0);
 }
 
-result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_cvttpd_pi32(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (const double *) impl.mTestFloatPointer1;
 
@@ -8950,7 +8950,7 @@ result_t test_mm_packus_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     return VALIDATE_UINT16_M128(c, d);
 }
 
-result_t test_mm_round_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_round_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *_a = (double *) impl.mTestFloatPointer1;
     double d[2] = {};
@@ -9015,7 +9015,7 @@ result_t test_mm_round_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     return validateDouble(ret, d[0], d[1]);
 }
 
-result_t test_mm_round_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
+OPTNONE result_t test_mm_round_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const float *_a = impl.mTestFloatPointer1;
     float f[4] = {};


### PR DESCRIPTION
### feat: Allow optimization option in sse2neon.h    
 Revert the previous restriction that some of the functions are forced
to not be optimized when compiling-time optimization options were
given.    
Now it is users' responsibility to ensure the behavior after
optimization.
Shifting the responsibility to the users enables sse2neon the run in
the optimized state in general, but not restricted by some specific
scenarios.

### feat: Use fesetround() and fegetround()    

Setting/getting rounding mode directly through fpcr with volatile
keyword could be unstable.
Therefore we use the C99 fesetround()/fegetround() here to ensure
the behavior.


closes #648