### PR TITLE
Fix performance regression after OPTNONE changes

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2187,7 +2187,7 @@ FORCE_INLINE int _mm_movemask_ps(__m128 a)
 // Multiply packed single-precision (32-bit) floating-point elements in a and b,
 // and store the results in dst.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mul_ps
-FORCE_INLINE_OPTNONE __m128 _mm_mul_ps(__m128 a, __m128 b)
+FORCE_INLINE __m128 _mm_mul_ps(__m128 a, __m128 b)
 {
     return vreinterpretq_m128_f32(
         vmulq_f32(vreinterpretq_f32_m128(a), vreinterpretq_f32_m128(b)));


### PR DESCRIPTION
The OPTNONE changes in #638 introduced 25% performance regression in Cycles render engine running on Apple Silicon:

  https://projects.blender.org/blender/blender/issues/126408

The reason for this is because as per Clang documentation optnone is incompatible with inline, so none of the functions that is marked as optnone is inlined. The biggest bottleneck for Cycles after that change is _mm_mul_ps.

This change makes it so _mm_mul_ps is inlined and is no longer marked as optnone. This solves the immediate performance regression, and the correctness is verified using the sse2neon's test suit on M2 Ultra and M3 Max, with various optimization levels (default, -O2, -O3).

Additionally, adding -Wstrict-aliasing flag does not introduce new warnings.