### PR TITLE
Add _MM_SHUFFLE2() macro for shuffle parameter for _mm_shuffle_pd()

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -334,6 +334,15 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
 #define _MM_SHUFFLE(fp3, fp2, fp1, fp0) \
     (((fp3) << 6) | ((fp2) << 4) | ((fp1) << 2) | ((fp0)))
 
+/**
+ * MACRO for shuffle parameter for _mm_shuffle_pd().
+ * Argument fp1 is a digit[01] that represents the fp from argument "b"
+ * of mm_shuffle_pd that will be placed in fp1 of result.
+ * fp0 is a digit[01] that represents the fp from argument "a" of mm_shuffle_pd
+ * that will be placed in fp0 of result.
+ */
+#define _MM_SHUFFLE2(fp1, fp0) (((fp1) << 1) | (fp0))
+
 #if __has_builtin(__builtin_shufflevector)
 #define _sse2neon_shuffle(type, a, b, ...) \
     __builtin_shufflevector(a, b, __VA_ARGS__)


### PR DESCRIPTION
This macro is defined in emmintrin.h and used sometimes by application. Cf https://clang.llvm.org/doxygen/emmintrin_8h.html#a3aeb3a59d7de7f9ca49c1153baa9da58 for its definition