### PR TITLE
Fix GitHub Action status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sse2neon
-![GitHub Actions](https://github.com/DLTcollab/sse2neon/workflows/Github%20Actions/badge.svg)
+![GitHub Actions](https://github.com/DLTcollab/sse2neon/workflows/GitHub%20Actions/badge.svg)
 
 A C/C++ header file that converts Intel SSE intrinsics to Arm/Aarch64 NEON intrinsics.
 


### PR DESCRIPTION
There was an typo in the URL, which cause the svg file can't display correctly:

![image](https://github.com/user-attachments/assets/482c5e1b-7425-4306-8933-7261a814ddeb)