### PR TITLE
Fix problem with _MM_GET_ROUNDING_MODE on certain platforms

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -1864,7 +1864,8 @@ FORCE_INLINE unsigned int _sse2neon_mm_get_flush_zero_mode(void)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_GET_ROUNDING_MODE
 FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE(void)
 {
-    switch (fegetround()) {
+    const int mask = FE_TONEAREST | FE_DOWNWARD | FE_UPWARD | FE_TOWARDZERO;
+    switch (fegetround() & mask) {
     case FE_TONEAREST:
         return _MM_ROUND_NEAREST;
     case FE_DOWNWARD:


### PR DESCRIPTION
fegetround() returns a bitmask and depending on the platform there may be bits used to indicate more than just the current rounding mode. In those cases _MM_GET_ROUNDING_MODE will always take the default switch case and incorrectly truncate even if _MM_ROUND_NEAREST was set.