### PR TITLE
Fix missing target pragma for ARMv8-A 32-bit

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -244,8 +244,10 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
 #endif
 }
 
-/* Architecture-specific build options */
-/* FIXME: #pragma GCC push_options is only available on GCC */
+/* Architecture-specific build options.
+ * Note: #pragma GCC push_options is GCC-specific; Clang is explicitly excluded
+ * via !defined(__clang__) checks below.
+ */
 #if defined(__GNUC__)
 #if defined(__arm__) && __ARM_ARCH == 7
 /* According to ARM C Language Extensions Architecture specification,
@@ -271,6 +273,7 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
 #endif
 #if !defined(__clang__) && !defined(_MSC_VER)
 #pragma GCC push_options
+#pragma GCC target("fpu=neon-fp-armv8")
 #endif
 #else
 #error \


### PR DESCRIPTION
ARMv8-A 32-bit case had #pragma GCC push_options without a corresponding target pragma, unlike ARMv7 (fpu=neon) and AArch64 (+simd). This adds the missing target("fpu=neon-fp-armv8") pragma to ensure consistent FPU configuration across all ARM architectures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing GCC target("fpu=neon-fp-armv8") pragma for ARMv8-A 32-bit to match push_options and ensure NEON/FPU settings are consistent. Aligns with ARMv7 (fpu=neon) and AArch64 (+simd) and prevents mismatched build flags on GCC (Clang excluded).

<sup>Written for commit cc37944bc344cd16f46be7920ac31fe43ebe4c05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

