### PR TITLE
Optimize _mm_shuffle_ps_3202 with vtrn

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -863,11 +863,16 @@ FORCE_INLINE __m128 _mm_shuffle_ps_2200(__m128 a, __m128 b)
 
 FORCE_INLINE __m128 _mm_shuffle_ps_3202(__m128 a, __m128 b)
 {
-    float32_t a0 = vgetq_lane_f32(vreinterpretq_f32_m128(a), 0);
-    float32x2_t a22 =
-        vdup_lane_f32(vget_high_f32(vreinterpretq_f32_m128(a)), 0);
-    float32x2_t a02 = vset_lane_f32(a0, a22, 1); /* TODO: use vzip ?*/
-    float32x2_t b32 = vget_high_f32(vreinterpretq_f32_m128(b));
+    float32x4_t _a = vreinterpretq_f32_m128(a);
+    float32x4_t _b = vreinterpretq_f32_m128(b);
+    /* vtrn interleaves elements: trn1({a[2],a[3]}, {a[0],a[1]}) = {a[2], a[0]}
+     */
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+    float32x2_t a02 = vtrn1_f32(vget_high_f32(_a), vget_low_f32(_a));
+#else
+    float32x2_t a02 = vtrn_f32(vget_high_f32(_a), vget_low_f32(_a)).val[0];
+#endif
+    float32x2_t b32 = vget_high_f32(_b);
     return vreinterpretq_m128_f32(vcombine_f32(a02, b32));
 }
 


### PR DESCRIPTION
This replaces scalar lane extraction + duplicate + insert sequence with single vtrn instruction for constructing {a[2], a[0]} pattern.

Before: vgetq_lane_f32 + vdup_lane_f32 + vset_lane_f32 (3 ops)
After:  vtrn1_f32 (ARMv8) or vtrn_f32 (ARMv7) (1 op)

While vzip was not suitable, vtrn achieves the same goal of reducing instruction count for this shuffle pattern.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized _mm_shuffle_ps_3202 to build {a[2], a[0]} with a single vtrn, reducing the sequence from 3 ops to 1. Uses vtrn1_f32 on ARMv8 (AArch64) and vtrn_f32 on ARMv7 for better throughput and smaller code.

<sup>Written for commit 9b62e4dc55fb6b759f63a3df9709958d1ae63f0f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



