### PR TITLE
Bump clang-format version requirement to 20+

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -6,7 +6,7 @@ set -x
 
 for file in ${SOURCES};
 do
-    clang-format-18 ${file} > expected-format
+    clang-format-20 ${file} > expected-format
     diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
 done
-exit $(clang-format-18 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $(clang-format-20 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,11 +130,17 @@ jobs:
 
   coding-style:
     runs-on: ubuntu-24.04
+    env:
+      CLANG_FORMAT_VERSION: 20
     steps:
       - name: checkout code
         uses: actions/checkout@v6
-      - name: style check
+      - name: install clang-format
         run: |
-            sudo apt-get install -q -y clang-format-18
-            sh .ci/check-format.sh
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-$CLANG_FORMAT_VERSION main"
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y clang-format-$CLANG_FORMAT_VERSION
+      - name: style check
+        run: sh .ci/check-format.sh
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We welcome all contributions from corporate, acaddemic and individual developers
 * All code must adhere to the existing C coding style (see below). While we are somewhat flexible in basic style, you will adhere to what is currently in place. Uncommented, complicated algorithmic constructs will be rejected.
 * All external pull requests must contain sufficient documentation in the pull request comments in order to be accepted.
 
-Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18 or later.
+Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 20 or later.
 
 Use the command `$ clang-format -i *.[ch]` to enforce a consistent coding style.
 

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,19 @@ ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
 endif
 	$(EXEC_WRAPPER) $^
 
+CLANG_FORMAT ?= $(shell command -v clang-format-20 2>/dev/null || \
+    (command -v clang-format >/dev/null 2>&1 && \
+     [ "$$(clang-format --version | sed 's/.*version \([0-9]*\).*/\1/')" -ge 20 ] 2>/dev/null && \
+     echo clang-format))
+
 indent:
 	@echo "Formatting files with clang-format.."
-	@if ! hash clang-format-18; then echo "clang-format-18 is required to indent"; fi
-	clang-format-18 -i sse2neon.h tests/*.cpp tests/*.h
+	@if [ -z "$(CLANG_FORMAT)" ]; then \
+	    echo "clang-format version 20+ is required"; \
+	    echo "Install clang-format-20 or ensure 'clang-format --version' reports 20+"; \
+	    exit 1; \
+	fi
+	$(CLANG_FORMAT) -i sse2neon.h tests/*.cpp tests/*.h
 
 .PHONY: clean check format
 clean:

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -206,10 +206,7 @@ FORCE_INLINE int64_t sse2neon_recast_f64_s64(double val)
 #define _sse2neon_return(ret) return ret
 #endif
 
-#define _sse2neon_init(...) \
-    {                       \
-        __VA_ARGS__         \
-    }
+#define _sse2neon_init(...) {__VA_ARGS__}
 
 /* Compiler barrier */
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -8265,8 +8262,8 @@ static uint16_t _sse2neon_cmp_word_equal_each(__m128i a,
 
 #define SSE2NEON_AGGREGATE_EQUAL_ORDER_IMPL(size, number_of_lanes, data_type)  \
     static uint16_t                                                            \
-        _sse2neon_aggregate_equal_ordered_##size##x##number_of_lanes(          \
-            int bound, int la, int lb, __m128i mtx[16])                        \
+    _sse2neon_aggregate_equal_ordered_##size##x##number_of_lanes(              \
+        int bound, int la, int lb, __m128i mtx[16])                            \
     {                                                                          \
         uint16_t res = 0;                                                      \
         uint16_t m1 = _sse2neon_static_cast(                                   \
@@ -8372,8 +8369,7 @@ FORCE_INLINE uint16_t _sse2neon_sido_negative(int res,
         break;
     }
 
-    return _sse2neon_static_cast(uint16_t,
-                                 res & ((bound == 8) ? 0xFF : 0xFFFF));
+    return _sse2neon_static_cast(uint16_t, res &((bound == 8) ? 0xFF : 0xFFFF));
 }
 
 FORCE_INLINE int _sse2neon_clz(unsigned int x)

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -9714,24 +9714,22 @@ result_t test_mm_testz_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 
 #define DEF_ENUM_MM_CMPESTRX_VARIANT(c, ...) c,
 
-#define EVAL_MM_CMPESTRX_TEST_CASE(c, type, data_type, im, IM)             \
-    do {                                                                   \
-        data_type *a = test_mm_##im##_##type##_data[c].a,                  \
-                  *b = test_mm_##im##_##type##_data[c].b;                  \
-        int la = test_mm_##im##_##type##_data[c].la,                       \
-            lb = test_mm_##im##_##type##_data[c].lb;                       \
-        const int imm8 = IMM_##c;                                          \
-        IIF(IM)                                                            \
-        (int expect = test_mm_##im##_##type##_data[c].expect,              \
-         data_type *expect = test_mm_##im##_##type##_data[c].expect);      \
-        __m128i ma, mb;                                                    \
-        memcpy(&ma, a, sizeof(ma));                                        \
-        memcpy(&mb, b, sizeof(mb));                                        \
-        IIF(IM)                                                            \
-        (int res = _mm_##im(ma, la, mb, lb, imm8),                         \
-         __m128i res = _mm_##im(ma, la, mb, lb, imm8));                    \
-        if (IIF(IM)(res != expect, memcmp(expect, &res, sizeof(__m128i)))) \
-            return TEST_FAIL;                                              \
+#define EVAL_MM_CMPESTRX_TEST_CASE(c, type, data_type, im, IM)               \
+    do {                                                                     \
+        data_type *a = test_mm_##im##_##type##_data[c].a,                    \
+                  *b = test_mm_##im##_##type##_data[c].b;                    \
+        int la = test_mm_##im##_##type##_data[c].la,                         \
+            lb = test_mm_##im##_##type##_data[c].lb;                         \
+        const int imm8 = IMM_##c;                                            \
+        IIF(IM)(int expect = test_mm_##im##_##type##_data[c].expect,         \
+                data_type *expect = test_mm_##im##_##type##_data[c].expect); \
+        __m128i ma, mb;                                                      \
+        memcpy(&ma, a, sizeof(ma));                                          \
+        memcpy(&mb, b, sizeof(mb));                                          \
+        IIF(IM)(int res = _mm_##im(ma, la, mb, lb, imm8),                    \
+                __m128i res = _mm_##im(ma, la, mb, lb, imm8));               \
+        if (IIF(IM)(res != expect, memcmp(expect, &res, sizeof(__m128i))))   \
+            return TEST_FAIL;                                                \
     } while (0);
 
 #define ENUM_MM_CMPESTRX_TEST_CASES(type, type_lower, data_type, func, FUNC, \
@@ -11051,22 +11049,20 @@ result_t test_mm_cmpgt_epi64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
 #define DEF_ENUM_MM_CMPISTRX_VARIANT(c, ...) c,
 
-#define EVAL_MM_CMPISTRX_TEST_CASE(c, type, data_type, im, IM)             \
-    do {                                                                   \
-        data_type *a = test_mm_##im##_##type##_data[c].a,                  \
-                  *b = test_mm_##im##_##type##_data[c].b;                  \
-        const int imm8 = IMM_##c;                                          \
-        IIF(IM)                                                            \
-        (int expect = test_mm_##im##_##type##_data[c].expect,              \
-         data_type *expect = test_mm_##im##_##type##_data[c].expect);      \
-        __m128i ma, mb;                                                    \
-        memcpy(&ma, a, sizeof(ma));                                        \
-        memcpy(&mb, b, sizeof(mb));                                        \
-        IIF(IM)                                                            \
-        (int res = _mm_##im(ma, mb, imm8),                                 \
-         __m128i res = _mm_##im(ma, mb, imm8));                            \
-        if (IIF(IM)(res != expect, memcmp(expect, &res, sizeof(__m128i)))) \
-            return TEST_FAIL;                                              \
+#define EVAL_MM_CMPISTRX_TEST_CASE(c, type, data_type, im, IM)               \
+    do {                                                                     \
+        data_type *a = test_mm_##im##_##type##_data[c].a,                    \
+                  *b = test_mm_##im##_##type##_data[c].b;                    \
+        const int imm8 = IMM_##c;                                            \
+        IIF(IM)(int expect = test_mm_##im##_##type##_data[c].expect,         \
+                data_type *expect = test_mm_##im##_##type##_data[c].expect); \
+        __m128i ma, mb;                                                      \
+        memcpy(&ma, a, sizeof(ma));                                          \
+        memcpy(&mb, b, sizeof(mb));                                          \
+        IIF(IM)(int res = _mm_##im(ma, mb, imm8),                            \
+                __m128i res = _mm_##im(ma, mb, imm8));                       \
+        if (IIF(IM)(res != expect, memcmp(expect, &res, sizeof(__m128i))))   \
+            return TEST_FAIL;                                                \
     } while (0);
 
 #define ENUM_MM_CMPISTRX_TEST_CASES(type, type_lower, data_type, func, FUNC, \


### PR DESCRIPTION
Update formatting toolchain to require clang-format version 20 or later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require clang-format 20+ across CI and local tooling to keep formatting consistent. CI installs v20, the check script and Makefile now target v20, and minor style updates were applied in code and tests.

- **Migration**
  - Install clang-format 20+ locally (ensure `clang-format --version` reports 20 or higher).
  - Use `make indent`; it will error if clang-format is below 20.

<sup>Written for commit 50477327bb6093a455e5692aff5aa8f7d127a535. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

