### PR TITLE
Remove obsolete FIXME in _mm_mulhi_epi16

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -4868,10 +4868,9 @@ FORCE_INLINE __m64 _mm_mul_su32(__m64 a, __m64 b)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_mulhi_epi16
 FORCE_INLINE __m128i _mm_mulhi_epi16(__m128i a, __m128i b)
 {
-    /* FIXME: issue with large values because of result saturation */
-    // int16x8_t ret = vqdmulhq_s16(vreinterpretq_s16_m128i(a),
-    // vreinterpretq_s16_m128i(b)); /* =2*a*b */ return
-    // vreinterpretq_m128i_s16(vshrq_n_s16(ret, 1));
+    // vmull_s16 is used instead of vqdmulhq_s16 to avoid saturation issues
+    // with large values (e.g., -32768 * -32768). vmull_s16 produces full 32-bit
+    // products without saturation.
     int16x4_t a3210 = vget_low_s16(vreinterpretq_s16_m128i(a));
     int16x4_t b3210 = vget_low_s16(vreinterpretq_s16_m128i(b));
     int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */


### PR DESCRIPTION
The comment referred to saturation issues with the old vqdmulhq_s16 approach (commented out), not the current implementation. The current vmull_s16-based implementation correctly handles all edge cases including -32768 * -32768 by computing full 32-bit products without saturation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an obsolete FIXME in _mm_mulhi_epi16 and clarified the comment to reflect the current vmull_s16-based implementation’s behavior. vmull_s16 computes full 32-bit products and correctly handles large values (e.g., -32768 * -32768), so there is no saturation issue; no functional changes.

<sup>Written for commit 5f70be7b158b379f1b6d613692b38dcd37dd9e94. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

