### PR TITLE
Add comprehensive precision flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Developers are advised to utilize sse2neon.h with GCC version 10 or higher, or C
 Though floating-point operations in NEON use the IEEE single-precision format, NEON does not fully comply to the IEEE standard when inputs or results are denormal or NaN values for minimizing power consumption as well as maximizing performance.
 Considering the balance between correctness and performance, `sse2neon` recognizes the following compile-time configurations:
 * `SSE2NEON_PRECISE_MINMAX`: Enable precise implementation of `_mm_min_{ps,pd}` and `_mm_max_{ps,pd}`. If you need consistent results such as handling with NaN values, enable it.
-* `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Netwon-Raphson iteration for accuracy.
-* `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Netwon-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_DIV`: Enable precise implementation of `_mm_rcp_ps` and `_mm_div_ps` by additional Newton-Raphson iteration for accuracy.
+* `SSE2NEON_PRECISE_SQRT`: Enable precise implementation of `_mm_sqrt_ps` and `_mm_rsqrt_ps` by additional Newton-Raphson iteration for accuracy.
 * `SSE2NEON_PRECISE_DP`: Enable precise implementation of `_mm_dp_pd`. When the conditional bit is not set, the corresponding multiplication would not be executed.
 * `SSE2NEON_SUPPRESS_WARNINGS`: Set this macro to disable the warning which is emitted by default when optimizations are enabled.
 


### PR DESCRIPTION
- Document all SSE2NEON_PRECISE_* flags with detailed trade-offs, affected functions, default/enabled behavior, and symptoms
- Add recommended configurations (Performance/Balanced/Exact)
- Fix _mm_div_ps to respect SSE2NEON_PRECISE_DIV on ARMv7, making it consistent with _mm_rcp_ps behavior
- Clarify that PRECISE_DIV affects _mm_rcp_ps on all architectures but only _mm_div_ps on ARMv7 (ARMv8 uses native vdivq_f32)
- Add warning that precision flags do not fix IEEE-754 corner cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive documentation for all SSE2NEON_PRECISE_* flags and fixes _mm_div_ps on ARMv7 to honor SSE2NEON_PRECISE_DIV for consistent precision with _mm_rcp_ps. Clarifies architecture-specific behavior and notes these flags don’t change IEEE-754 edge-case handling.

- **New Features**
  - Documented all precision flags with trade-offs, affected intrinsics, defaults, and symptoms.
  - Added recommended configurations: Performance, Balanced, Exact.
  - Clarified PRECISE_DIV affects _mm_rcp_* on all architectures and _mm_div_* only on ARMv7; flags do not fix IEEE-754 corner cases.

- **Bug Fixes**
  - _mm_div_ps on ARMv7 now respects SSE2NEON_PRECISE_DIV, adding an extra Newton-Raphson refinement when enabled.

<sup>Written for commit 1e3e5708cd94987555e818c075eafc62003d84a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

