### PR TITLE
CI: Add clang-tidy static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,49 @@
+# clang-tidy configuration for sse2neon
+# Focus: performance, bugprone, and cppcoreguidelines checks
+# Excludes checks that produce false positives in SIMD/intrinsics code
+
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  cppcoreguidelines-*,
+  -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
+  -bugprone-switch-missing-default-case,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-no-malloc,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-use-enum-class,
+  -performance-enum-size,
+  -performance-no-int-to-ptr,
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: 'sse2neon\.h'
+
+CheckOptions:
+  - key: bugprone-assert-side-effect.AssertMacros
+    value: assert
+  - key: bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value: false
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: '__m128;__m128i;__m128d;__m64'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,19 +146,29 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: make SANITIZE=${{ matrix.sanitizer }} check
 
-  coding-style:
+  static-analysis:
     runs-on: ubuntu-24.04
     env:
-      CLANG_FORMAT_VERSION: 20
+      LLVM_VERSION: 20
     steps:
       - name: checkout code
         uses: actions/checkout@v6
-      - name: install clang-format
+      - name: install clang tools
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-$CLANG_FORMAT_VERSION main"
+          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-$LLVM_VERSION main"
           sudo apt-get update -q -y
-          sudo apt-get install -q -y clang-format-$CLANG_FORMAT_VERSION
+          sudo apt-get install -q -y clang-format-$LLVM_VERSION clang-tidy-$LLVM_VERSION \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: style check
         run: sh .ci/check-format.sh
         shell: bash
+      - name: clang-tidy
+        run: |
+          clang-tidy-$LLVM_VERSION sse2neon.h \
+            --warnings-as-errors='' \
+            -- -x c++ -std=gnu++14 -I. \
+            --target=aarch64-linux-gnu \
+            --gcc-toolchain=/usr \
+            -isystem /usr/aarch64-linux-gnu/include \
+            -march=armv8-a+simd+crypto+crc


### PR DESCRIPTION
This integrates clang-tidy into the static-analysis CI job with checks:
- bugprone-*
- performance-*
- cppcoreguidelines-*

The configuration excludes checks that produce false positives in SIMD/intrinsics code (e.g., reinterpret_cast, magic numbers, pointer arithmetic). Analysis targets the NEON implementation code path using ARM64 cross-compilation headers.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clang-tidy static analysis to CI for sse2neon.h. Focuses on bugprone, performance, and cppcoreguidelines checks with SIMD-friendly exclusions and targets the ARM64 NEON path.

- **New Features**
  - Added a .clang-tidy config enabling bugprone-*, performance-*, and cppcoreguidelines-* with exclusions for common intrinsics false positives (e.g., magic numbers, pointer arithmetic, C-style/reinterpret casts).
  - Updated the CI “static-analysis” job to install clang-tidy 20 and ARM64 cross headers, then run clang-tidy against aarch64 with GNU++14 and ARMv8+SIMD flags.
  - Limited analysis to sse2neon.h via HeaderFilterRegex; warnings are not treated as errors.

<sup>Written for commit d626d280a5ba6eebbbf346134e9ba2321e3f546c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



