### PR TITLE
Add performance tier analysis

### DIFF
--- a/.ci/check-perf-tier.sh
+++ b/.ci/check-perf-tier.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Check if perf-tier.md is in sync with sse2neon.h
+# Returns 0 if in sync, 1 if out of sync
+
+set -e
+
+# Generate fresh report (includes header)
+python3 scripts/gen-perf-report.py > perf-tier-generated.md
+
+# Direct comparison - gen-perf-report.py now outputs the complete file
+if diff -q perf-tier.md perf-tier-generated.md > /dev/null 2>&1; then
+    echo "perf-tier.md is up to date"
+    rm -f perf-tier-generated.md
+    exit 0
+else
+    echo "perf-tier.md is out of sync with sse2neon.h"
+    echo ""
+    echo "To regenerate:"
+    echo "  python3 scripts/gen-perf-report.py > perf-tier.md"
+    echo ""
+    echo "For detailed analysis:"
+    echo "  python3 scripts/analyze-tiers.py --markdown"
+    rm -f perf-tier-generated.md
+    exit 1
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,3 +172,71 @@ jobs:
             --gcc-toolchain=/usr \
             -isystem /usr/aarch64-linux-gnu/include \
             -march=armv8-a+simd+crypto+crc
+
+  perf-tier-check:
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: install unifdef
+        run: sudo apt-get install -y unifdef
+      - name: check perf-tier.md
+        id: check
+        run: |
+          if sh .ci/check-perf-tier.sh; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+      - name: post reminder comment
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '### Performance Tier Documentation Reminder',
+              '',
+              'The `perf-tier.md` file appears to be out of sync with the current `sse2neon.h` implementation.',
+              '',
+              'This is **not an error** - just a reminder to update the documentation if your changes affect intrinsic implementations.',
+              '',
+              'To regenerate the performance tier report:',
+              '```bash',
+              'python3 scripts/gen-perf-report.py > perf-tier.md',
+              '```',
+              '',
+              'For detailed analysis:',
+              '```bash',
+              'python3 scripts/analyze-tiers.py --markdown',
+              '```'
+            ].join('\n');
+
+            // Check if we already posted this comment (paginate to handle PRs with many comments)
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('Performance Tier Documentation Reminder')
+            );
+
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Header file | Extension |
 `sse2neon` supports SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, and AES extensions.
 
 Some SSE intrinsics map directly to a single NEON intrinsic (e.g., `_mm_loadu_si128` → `vld1q_s32`),
-while others require multiple NEON instructions (e.g., `_mm_maddubs_epi16` uses 13+ instructions).
+while others require multiple NEON instructions (e.g., `_mm_maddubs_epi16` uses 13 instructions).
+
+See [perf-tier.md](perf-tier.md) for detailed performance tier classification of all intrinsics.
 
 ### Floating-point Compatibility
 

--- a/perf-tier.md
+++ b/perf-tier.md
@@ -1,0 +1,208 @@
+# SSE2NEON Performance Tier Analysis (AArch64)
+
+This document classifies SSE intrinsics by their NEON implementation complexity
+on AArch64 (ARMv8-A 64-bit). Analysis uses `unifdef` to preprocess conditional
+compilation paths, providing accurate instruction counts for the AArch64 target.
+
+> Note: ARMv7 (32-bit ARM) implementations may differ significantly due to
+> missing instructions like `vrndnq_f32` (directed rounding) and require fallback
+> paths. Use `--no-unifdef` flag to analyze the raw file including all code paths.
+
+To regenerate this file:
+```bash
+python3 scripts/gen-perf-report.py > perf-tier.md
+```
+
+For detailed analysis:
+```bash
+python3 scripts/analyze-tiers.py              # AArch64 analysis (default)
+python3 scripts/analyze-tiers.py --no-unifdef # Raw file (all architectures)
+python3 scripts/analyze-tiers.py --json       # JSON output
+python3 scripts/analyze-tiers.py --tier 4     # Filter by tier
+```
+
+---
+
+## SSE2NEON Performance Classification (AArch64)
+
+Based on static analysis of NEON instruction counts per SSE intrinsic.
+Cycle estimates based on ARM Cortex-A72 (ARMv8-A) Software Optimization Guide.
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Total SSE Intrinsics | 455 |
+| Direct Mappings (T1) | 341 (74.9%) |
+| Moderate Emulation (T2-T3) | 109 (24.0%) |
+| Complex Emulation (T4) | 5 (1.1%) |
+| Avg NEON Ops/Intrinsic | 1.81 |
+
+### Performance Tiers
+
+| Tier | NEON Ops | Estimated Cycles | Description |
+|------|----------|------------------|-------------|
+| T1 | 1-2 | 1-3 | Direct NEON mapping, near-native performance |
+| T2 | 3-5 | 4-8 | Few NEON operations, slight overhead |
+| T3 | 6-10 | 8-15 | Moderate emulation, noticeable overhead |
+| T4 | 10+ | 15-50+ | Complex/algorithmic, significant overhead |
+
+### Performance-Critical Intrinsics (T4)
+
+These intrinsics have significant emulation overhead. Consider alternative
+algorithms when porting performance-critical code.
+
+| Intrinsic | NEON Ops | Notes |
+|-----------|----------|-------|
+| `_mm_mpsadbw_epu8` | 22 | SAD computation, very expensive |
+| `_mm_rsqrt_ps` | 13 | Newton-Raphson refinement |
+| `_mm_sqrt_ps` | 13 | Newton-Raphson refinement |
+| `_mm_maddubs_epi16` | 13 | Multiply-add with widening |
+| `_mm_dp_ps` | 11 |  |
+
+### Efficient Intrinsics (T1 - Single NEON Instruction)
+
+These intrinsics map directly to single NEON instructions:
+
+- Arithmetic: `_mm_abs_epi16`, `_mm_abs_epi32`, `_mm_abs_epi8`, `_mm_abs_pi16`, `_mm_abs_pi32`, `_mm_abs_pi8`, `_mm_add_epi16`, `_mm_add_epi32`, ... (+35 more)
+- Comparison: `_mm_cmpeq_epi16`, `_mm_cmpeq_epi32`, `_mm_cmpeq_epi64`, `_mm_cmpeq_epi8`, `_mm_cmpeq_pd`, `_mm_cmpeq_ps`, `_mm_cmpgt_epi16`, `_mm_cmpgt_epi32`, ... (+9 more)
+- Logical: `_mm_and_pd`, `_mm_and_ps`, `_mm_and_si128`, `_mm_andnot_pd`, `_mm_andnot_ps`, `_mm_andnot_si128`, `_mm_floor_pd`, `_mm_floor_ps`, ... (+18 more)
+- Load/Store: `_mm_load1_pd`, `_mm_load1_ps`, `_mm_load_pd`, `_mm_load_ps`, `_mm_load_si128`, `_mm_loadu_ps`, `_mm_loadu_si128`, `_mm_set1_epi16`, ... (+33 more)
+- Conversion: `_mm_cvt_ps2pi`, `_mm_cvt_si2ss`, `_mm_cvt_ss2si`, `_mm_cvtepi32_ps`, `_mm_cvtps_epi32`, `_mm_cvtps_pi16`, `_mm_cvtsd_f64`, `_mm_cvtsd_si32`, ... (+12 more)
+- Math: `_mm_ceil_pd`, `_mm_ceil_ps`, `_mm_floor_pd`, `_mm_floor_ps`, `_mm_max_epi16`, `_mm_max_epi32`, `_mm_max_epi8`, `_mm_max_epu16`, ... (+13 more)
+
+### Complete Tier Classification
+
+<details>
+<summary>Click to expand full list</summary>
+
+#### Tier 1 (341 intrinsics)
+
+`_mm_abs_epi16`, `_mm_abs_epi32`, `_mm_abs_epi8`, `_mm_abs_pi16`
+`_mm_abs_pi32`, `_mm_abs_pi8`, `_mm_add_epi16`, `_mm_add_epi32`
+`_mm_add_epi64`, `_mm_add_epi8`, `_mm_add_pd`, `_mm_add_ps`, `_mm_add_sd`
+`_mm_add_si64`, `_mm_adds_epi16`, `_mm_adds_epi8`, `_mm_adds_epu16`
+`_mm_adds_epu8`, `_mm_addsub_pd`, `_mm_addsub_ps`, `_mm_and_pd`, `_mm_and_ps`
+`_mm_and_si128`, `_mm_andnot_pd`, `_mm_andnot_ps`, `_mm_andnot_si128`
+`_mm_avg_epu16`, `_mm_avg_epu8`, `_mm_avg_pu16`, `_mm_avg_pu8`
+`_mm_blend_ps`, `_mm_blendv_epi8`, `_mm_blendv_pd`, `_mm_blendv_ps`
+`_mm_castpd_ps`, `_mm_castpd_si128`, `_mm_castps_pd`, `_mm_castps_si128`
+`_mm_castsi128_pd`, `_mm_castsi128_ps`, `_mm_ceil_pd`, `_mm_ceil_ps`
+`_mm_ceil_sd`, `_mm_ceil_ss`, `_mm_clflush`, `_mm_cmpeq_epi16`
+`_mm_cmpeq_epi32`, `_mm_cmpeq_epi64`, `_mm_cmpeq_epi8`, `_mm_cmpeq_pd`
+`_mm_cmpeq_ps`, `_mm_cmpeq_sd`, `_mm_cmpeq_ss`, `_mm_cmpestra`
+`_mm_cmpestrc`, `_mm_cmpestri`, `_mm_cmpestrm`, `_mm_cmpestro`
+`_mm_cmpestrs`, `_mm_cmpestrz`, `_mm_cmpge_pd`, `_mm_cmpge_ps`
+`_mm_cmpge_sd`, `_mm_cmpge_ss`, `_mm_cmpgt_epi16`, `_mm_cmpgt_epi32`
+`_mm_cmpgt_epi64`, `_mm_cmpgt_epi8`, `_mm_cmpgt_pd`, `_mm_cmpgt_ps`
+`_mm_cmpgt_sd`, `_mm_cmpgt_ss`, `_mm_cmpistra`, `_mm_cmpistrc`
+`_mm_cmpistri`, `_mm_cmpistrm`, `_mm_cmpistro`, `_mm_cmpistrs`
+`_mm_cmpistrz`, `_mm_cmple_pd`, `_mm_cmple_ps`, `_mm_cmple_sd`
+`_mm_cmple_ss`, `_mm_cmplt_epi16`, `_mm_cmplt_epi32`, `_mm_cmplt_epi8`
+`_mm_cmplt_pd`, `_mm_cmplt_ps`, `_mm_cmplt_sd`, `_mm_cmplt_ss`
+`_mm_cmpneq_pd`, `_mm_cmpneq_ps`, `_mm_cmpneq_sd`, `_mm_cmpneq_ss`
+`_mm_cmpnge_ps`, `_mm_cmpnge_sd`, `_mm_cmpnge_ss`, `_mm_cmpngt_ps`
+`_mm_cmpngt_sd`, `_mm_cmpngt_ss`, `_mm_cmpnle_ps`, `_mm_cmpnle_sd`
+`_mm_cmpnle_ss`, `_mm_cmpnlt_ps`, `_mm_cmpnlt_sd`, `_mm_cmpnlt_ss`
+`_mm_cmpord_sd`, `_mm_cmpord_ss`, `_mm_cmpunord_sd`, `_mm_cmpunord_ss`
+`_mm_comieq_sd`, `_mm_comieq_ss`, `_mm_comige_sd`, `_mm_comige_ss`
+`_mm_comigt_sd`, `_mm_comigt_ss`, `_mm_comile_sd`, `_mm_comile_ss`
+`_mm_comilt_sd`, `_mm_comilt_ss`, `_mm_comineq_sd`, `_mm_comineq_ss`
+`_mm_crc32_u16`, `_mm_cvt_ps2pi`, `_mm_cvt_si2ss`, `_mm_cvt_ss2si`
+`_mm_cvtepi16_epi32`, `_mm_cvtepi32_epi64`, `_mm_cvtepi32_ps`
+`_mm_cvtepi8_epi16`, `_mm_cvtepu16_epi32`, `_mm_cvtepu32_epi64`
+`_mm_cvtepu8_epi16`, `_mm_cvtpd_epi32`, `_mm_cvtpi16_ps`, `_mm_cvtpi32_pd`
+`_mm_cvtpi32x2_ps`, `_mm_cvtps_epi32`, `_mm_cvtps_pd`, `_mm_cvtps_pi16`
+`_mm_cvtpu16_ps`, `_mm_cvtsd_f64`, `_mm_cvtsd_si32`, `_mm_cvtsd_si64`
+`_mm_cvtsi128_si32`, `_mm_cvtsi128_si64`, `_mm_cvtsi32_sd`
+`_mm_cvtsi32_si128`, `_mm_cvtsi64_sd`, `_mm_cvtsi64_si128`, `_mm_cvtsi64_ss`
+`_mm_cvtss_f32`, `_mm_cvtss_sd`, `_mm_cvtss_si64`, `_mm_cvtt_ps2pi`
+`_mm_cvtt_ss2si`, `_mm_cvttpd_epi32`, `_mm_cvttps_epi32`, `_mm_cvttsd_si32`
+`_mm_cvttsd_si64`, `_mm_cvttss_si64`, `_mm_div_pd`, `_mm_div_ps`
+`_mm_div_ss`, `_mm_empty`, `_mm_floor_pd`, `_mm_floor_ps`, `_mm_floor_sd`
+`_mm_floor_ss`, `_mm_free`, `_mm_hadd_epi16`, `_mm_hadd_epi32`, `_mm_hadd_pd`
+`_mm_hadd_pi16`, `_mm_hadd_pi32`, `_mm_hadd_ps`, `_mm_lfence`, `_mm_load1_pd`
+`_mm_load1_ps`, `_mm_load_pd`, `_mm_load_ps`, `_mm_load_sd`, `_mm_load_si128`
+`_mm_load_ss`, `_mm_loadr_pd`, `_mm_loadu_pd`, `_mm_loadu_ps`
+`_mm_loadu_si128`, `_mm_loadu_si16`, `_mm_loadu_si32`, `_mm_loadu_si64`
+`_mm_max_epi16`, `_mm_max_epi32`, `_mm_max_epi8`, `_mm_max_epu16`
+`_mm_max_epu32`, `_mm_max_epu8`, `_mm_max_pi16`, `_mm_max_pu8`, `_mm_max_sd`
+`_mm_max_ss`, `_mm_mfence`, `_mm_min_epi16`, `_mm_min_epi32`, `_mm_min_epi8`
+`_mm_min_epu16`, `_mm_min_epu32`, `_mm_min_epu8`, `_mm_min_pi16`
+`_mm_min_pu8`, `_mm_min_sd`, `_mm_min_ss`, `_mm_move_epi64`, `_mm_move_ss`
+`_mm_movedup_pd`, `_mm_movehdup_ps`, `_mm_moveldup_ps`, `_mm_movepi64_pi64`
+`_mm_movpi64_epi64`, `_mm_mul_epi32`, `_mm_mul_epu32`, `_mm_mul_pd`
+`_mm_mul_ps`, `_mm_mul_sd`, `_mm_mul_ss`, `_mm_mul_su32`, `_mm_mulhi_pu16`
+`_mm_mulhrs_pi16`, `_mm_mullo_epi16`, `_mm_mullo_epi32`, `_mm_or_pd`
+`_mm_or_ps`, `_mm_or_si128`, `_mm_pause`, `_mm_prefetch`, `_mm_rcp_ss`
+`_mm_round_pd`, `_mm_round_ps`, `_mm_round_sd`, `_mm_round_ss`
+`_mm_rsqrt_ss`, `_mm_sad_epu8`, `_mm_set1_epi16`, `_mm_set1_epi32`
+`_mm_set1_epi64`, `_mm_set1_epi64x`, `_mm_set1_epi8`, `_mm_set1_pd`
+`_mm_set1_ps`, `_mm_set_epi16`, `_mm_set_epi32`, `_mm_set_epi64`
+`_mm_set_epi8`, `_mm_set_pd`, `_mm_set_ps`, `_mm_set_ps1`, `_mm_set_sd`
+`_mm_set_ss`, `_mm_setcsr`, `_mm_setr_epi16`, `_mm_setr_epi32`
+`_mm_setr_epi64`, `_mm_setr_epi8`, `_mm_setr_pd`, `_mm_setr_ps`
+`_mm_setzero_pd`, `_mm_setzero_ps`, `_mm_setzero_si128`, `_mm_sfence`
+`_mm_shuffle_epi_0321`, `_mm_shuffle_epi_1010`, `_mm_shuffle_epi_2103`
+`_mm_sll_epi16`, `_mm_sll_epi32`, `_mm_sll_epi64`, `_mm_slli_epi16`
+`_mm_slli_epi32`, `_mm_slli_epi64`, `_mm_sqrt_pd`, `_mm_sqrt_sd`
+`_mm_sqrt_ss`, `_mm_srai_epi16`, `_mm_srl_epi16`, `_mm_srl_epi32`
+`_mm_srl_epi64`, `_mm_store_pd`, `_mm_store_ps`, `_mm_store_sd`
+`_mm_store_si128`, `_mm_store_ss`, `_mm_storeh_pd`, `_mm_storeh_pi`
+`_mm_storel_epi64`, `_mm_storel_pd`, `_mm_storel_pi`, `_mm_storer_pd`
+`_mm_storeu_pd`, `_mm_storeu_ps`, `_mm_storeu_si128`, `_mm_storeu_si16`
+`_mm_storeu_si32`, `_mm_storeu_si64`, `_mm_stream_load_si128`
+`_mm_stream_pd`, `_mm_stream_pi`, `_mm_stream_ps`, `_mm_stream_si128`
+`_mm_stream_si32`, `_mm_stream_si64`, `_mm_sub_epi16`, `_mm_sub_epi32`
+`_mm_sub_epi64`, `_mm_sub_epi8`, `_mm_sub_pd`, `_mm_sub_ps`, `_mm_sub_sd`
+`_mm_sub_si64`, `_mm_sub_ss`, `_mm_subs_epi16`, `_mm_subs_epi8`
+`_mm_subs_epu16`, `_mm_subs_epu8`, `_mm_test_all_ones`, `_mm_undefined_pd`
+`_mm_undefined_ps`, `_mm_undefined_si128`, `_mm_unpackhi_epi16`
+`_mm_unpackhi_epi32`, `_mm_unpackhi_epi64`, `_mm_unpackhi_epi8`
+`_mm_unpackhi_pd`, `_mm_unpackhi_ps`, `_mm_unpacklo_epi16`
+`_mm_unpacklo_epi32`, `_mm_unpacklo_epi64`, `_mm_unpacklo_epi8`
+`_mm_unpacklo_pd`, `_mm_unpacklo_ps`, `_mm_xor_pd`, `_mm_xor_ps`
+`_mm_xor_si128`
+
+#### Tier 2 (99 intrinsics)
+
+`_mm_add_ss`, `_mm_cmpnge_pd`, `_mm_cmpngt_pd`, `_mm_cmpnle_pd`
+`_mm_cmpnlt_pd`, `_mm_cmpord_pd`, `_mm_cmpord_ps`, `_mm_cmpunord_pd`
+`_mm_cmpunord_ps`, `_mm_cvt_pi2ps`, `_mm_cvtepi16_epi64`, `_mm_cvtepi32_pd`
+`_mm_cvtepi8_epi32`, `_mm_cvtepu16_epi64`, `_mm_cvtepu8_epi32`
+`_mm_cvtpd_pi32`, `_mm_cvtpd_ps`, `_mm_cvtpi32_ps`, `_mm_cvtpi8_ps`
+`_mm_cvtps_pi8`, `_mm_cvtpu8_ps`, `_mm_cvtsd_ss`, `_mm_cvttpd_pi32`
+`_mm_div_sd`, `_mm_dp_pd`, `_mm_hadds_epi16`, `_mm_hadds_pi16`
+`_mm_hsub_epi16`, `_mm_hsub_epi32`, `_mm_hsub_pd`, `_mm_hsub_pi16`
+`_mm_hsub_pi32`, `_mm_hsub_ps`, `_mm_hsubs_epi16`, `_mm_hsubs_pi16`
+`_mm_loadh_pd`, `_mm_loadh_pi`, `_mm_loadl_epi64`, `_mm_loadl_pd`
+`_mm_loadl_pi`, `_mm_loadr_ps`, `_mm_madd_epi16`, `_mm_maskmove_si64`
+`_mm_maskmoveu_si128`, `_mm_max_pd`, `_mm_max_ps`, `_mm_min_pd`, `_mm_min_ps`
+`_mm_move_sd`, `_mm_movehl_ps`, `_mm_movelh_ps`, `_mm_movemask_pd`
+`_mm_movemask_pi8`, `_mm_movemask_ps`, `_mm_mulhi_epi16`, `_mm_mulhi_epu16`
+`_mm_mulhrs_epi16`, `_mm_packs_epi16`, `_mm_packs_epi32`, `_mm_packus_epi16`
+`_mm_packus_epi32`, `_mm_rcp_ps`, `_mm_set_epi64x`, `_mm_shuffle_epi8`
+`_mm_shuffle_epi_0101`, `_mm_shuffle_epi_0122`, `_mm_shuffle_epi_1001`
+`_mm_shuffle_epi_1032`, `_mm_shuffle_epi_2211`, `_mm_shuffle_epi_2301`
+`_mm_shuffle_epi_3332`, `_mm_shuffle_pi8`, `_mm_shuffle_ps_0011`
+`_mm_shuffle_ps_0022`, `_mm_shuffle_ps_0101`, `_mm_shuffle_ps_0321`
+`_mm_shuffle_ps_1001`, `_mm_shuffle_ps_1010`, `_mm_shuffle_ps_1032`
+`_mm_shuffle_ps_1133`, `_mm_shuffle_ps_2103`, `_mm_shuffle_ps_2200`
+`_mm_shuffle_ps_2301`, `_mm_shuffle_ps_3202`, `_mm_shuffle_ps_3210`
+`_mm_sign_epi16`, `_mm_sign_epi32`, `_mm_sign_epi8`, `_mm_sign_pi16`
+`_mm_sign_pi32`, `_mm_sign_pi8`, `_mm_sra_epi16`, `_mm_sra_epi32`
+`_mm_store_pd1`, `_mm_store_ps1`, `_mm_storer_ps`, `_mm_test_all_zeros`
+`_mm_testc_si128`, `_mm_testz_si128`
+
+#### Tier 3 (10 intrinsics)
+
+`_mm_cvtepi8_epi64`, `_mm_cvtepu8_epi64`, `_mm_maddubs_pi16`
+`_mm_minpos_epu16`, `_mm_movemask_epi8`, `_mm_sad_pu8`, `_mm_shuffle_ps_2001`
+`_mm_shuffle_ps_2010`, `_mm_shuffle_ps_2032`, `_mm_test_mix_ones_zeros`
+
+#### Tier 4 (5 intrinsics)
+
+`_mm_dp_ps`, `_mm_maddubs_epi16`, `_mm_mpsadbw_epu8`, `_mm_rsqrt_ps`
+`_mm_sqrt_ps`
+
+</details>

--- a/scripts/analyze-tiers.py
+++ b/scripts/analyze-tiers.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""
+SSE2NEON Intrinsic Tier Analysis Tool
+
+Analyzes sse2neon.h to classify intrinsics by their NEON instruction complexity
+and estimate relative performance tiers.
+
+This tool uses unifdef to preprocess the header for AArch64-specific analysis,
+removing ARMv7 fallback paths that would skew instruction counts.
+
+Performance Tiers (AArch64/ARMv8-A Reference):
+  T1 (1:1-2):  Direct NEON mapping, 1-2 instructions, ~1-2 cycles
+  T2 (1:3-5):  Few NEON ops, 3-5 instructions, ~3-8 cycles
+  T3 (1:6-10): Moderate emulation, 6-10 instructions, ~10-20 cycles
+  T4 (1:10+):  Complex emulation, 10+ instructions or algorithmic, ~20+ cycles
+
+Usage:
+  python3 scripts/analyze-tiers.py [--json] [--markdown] [--verbose]
+  python3 scripts/analyze-tiers.py --no-unifdef  # Analyze raw file without preprocessing
+"""
+
+import re
+import sys
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Optional
+from collections import defaultdict
+from pathlib import Path
+
+# unifdef flags for AArch64 analysis
+# These define the target platform and enable AArch64-specific code paths
+UNIFDEF_AARCH64_FLAGS = [
+    '-DSSE2NEON_ARCH_AARCH64=1',
+    '-D__aarch64__=1',
+    '-D__ARM_FEATURE_DIRECTED_ROUNDING=1',
+    '-D__ARM_FEATURE_FMA=1',
+    '-D__ARM_FEATURE_CRYPTO=1',
+    '-D__ARM_FEATURE_CRC32=1',
+    # Undefine ARMv7-specific or optional features
+    '-U__ARM_FEATURE_FRINT',  # ARMv8.5+ optional feature
+]
+
+# NEON intrinsic patterns that map to actual instructions.
+# Each pattern corresponds to one or more ARM NEON instructions.
+# Patterns are grouped by category with typical cycle counts noted.
+NEON_INTRINSIC_PATTERNS = [
+    # Load/Store (1 cycle typically)
+    # Include _lane variants for lane-specific load/store
+    r'vld[1234]q?(_lane)?_[a-z0-9_]+',
+    r'vst[1234]q?(_lane)?_[a-z0-9_]+',
+    r'vget[q]?_lane_[a-z0-9_]+',
+    r'vget_(low|high)_[a-z0-9_]+',
+    r'vcombine_[a-z0-9_]+',
+    r'vdup[q]?_n_[a-z0-9_]+',
+    r'vdupq?_lane[q]?_[a-z0-9_]+',
+    r'vmovq?_n_[a-z0-9_]+',
+    r'vcreate_[a-z0-9_]+',
+    r'vset_lane_[a-z0-9_]+',
+    r'vsetq_lane_[a-z0-9_]+',
+
+    # Arithmetic (1 cycle)
+    # Separate mul to add _lane variants
+    r'v(add|sub|neg|abs|div)[q]?_[a-z0-9_]+',
+    r'vmul[q]?(_lane[q]?)?_[a-z0-9_]+',
+    r'vmla[l]?[q]?(_lane[q]?)?_[a-z0-9_]+',
+    r'vmls[l]?[q]?(_lane[q]?)?_[a-z0-9_]+',
+
+    # FMA with lane variants (1-2 cycles)
+    r'vfma[q]?_[a-z0-9_]+',
+    r'vfms[q]?_[a-z0-9_]+',
+    r'vfma_lane[q]?_[a-z0-9_]+',
+    r'vfms_lane[q]?_[a-z0-9_]+',
+
+    # Min/Max (1 cycle)
+    r'v(min|max)[q]?_[a-z0-9_]+',
+    r'vp(min|max)[q]?_[a-z0-9_]+',
+
+    # Comparison (1 cycle)
+    r'vc(eq|gt|ge|lt|le)[q]?_[a-z0-9_]+',
+
+    # Bitwise test (1 cycle)
+    r'vtst[q]?_[a-z0-9_]+',
+
+    # Logical (1 cycle)
+    r'v(and|orr|eor|bic|orn|mvn|bsl)[q]?_[a-z0-9_]+',
+
+    # Shift (1 cycle)
+    r'vshl[q]?_[a-z0-9_]+',
+    r'vshr[q]?_n_[a-z0-9_]+',
+    r'vrshr[q]?_n_[a-z0-9_]+',
+    r'vsra[q]?_n_[a-z0-9_]+',
+    r'vrsra[q]?_n_[a-z0-9_]+',
+    r'vshl_n_[a-z0-9_]+',
+    r'vshlq_n_[a-z0-9_]+',
+    r'vqshl[q]?_[a-z0-9_]+',
+
+    # Rounding/Conversion (1-2 cycles)
+    r'vcvt[q]?_[a-z0-9_]+',
+    r'vrnd[nmap]?[q]?_[a-z0-9_]+',
+
+    # Reciprocal estimates (3-5 cycles with refinement)
+    r'vrecpe[q]?_[a-z0-9_]+',
+    r'vrecps[q]?_[a-z0-9_]+',
+    r'vrsqrte[q]?_[a-z0-9_]+',
+    r'vrsqrts[q]?_[a-z0-9_]+',
+    r'vsqrt[q]?_[a-z0-9_]+',
+
+    # Pairwise (1-2 cycles)
+    r'vpadd[lq]?_[a-z0-9_]+',
+    r'vpadal[q]?_[a-z0-9_]+',
+
+    # Table lookup (2-4 cycles)
+    r'vqtbl[1234]q?_[a-z0-9_]+',
+    r'vqtbx[1234]q?_[a-z0-9_]+',
+    r'vtbl[1234]_[a-z0-9_]+',
+    r'vtbx[1234]_[a-z0-9_]+',
+
+    # Zip/Unzip/Transpose (1-2 cycles)
+    r'vzip[12]?q?_[a-z0-9_]+',
+    r'vuzp[12]?q?_[a-z0-9_]+',
+    r'vtrn[12]?q?_[a-z0-9_]+',
+
+    # Extract (1 cycle)
+    r'vext[q]?_[a-z0-9_]+',
+
+    # Reverse (1 cycle)
+    r'vrev(16|32|64)[q]?_[a-z0-9_]+',
+
+    # Narrow/Widen (1 cycle)
+    r'vmovl_[a-z0-9_]+',
+    r'vmovn_[a-z0-9_]+',
+    r'vqmovn_[a-z0-9_]+',
+    r'vqmovun_[a-z0-9_]+',
+
+    # Saturating arithmetic (1 cycle)
+    r'vq(add|sub|abs|neg)[q]?_[a-z0-9_]+',
+
+    # Saturating doubling multiply high (1-2 cycles)
+    # Include _lane variants and vqrdmulh
+    r'v(qrdmulh|qdmulh)[q]?(_lane[q]?)?_[a-z0-9_]+',
+    r'vqdmlal(_lane)?_[a-z0-9_]+',
+    r'vqdmlsl(_lane)?_[a-z0-9_]+',
+
+    # Count (1 cycle)
+    r'v(cnt|clz|cls)[q]?_[a-z0-9_]+',
+
+    # CRC (crypto extension, 1-3 cycles)
+    r'__crc32[a-z]*',
+    r'vcrc32[a-z]*',
+
+    # AES (crypto extension, 3-4 cycles)
+    r'vaes[ed]q_[a-z0-9_]+',
+    r'vaes[im]?cq_[a-z0-9_]+',
+
+    # SHA (crypto extension)
+    r'vsha[0-9a-z]+_[a-z0-9_]+',
+
+    # Polynomial multiply
+    r'vmull_p[0-9]+',
+    r'vmull_high_p[0-9]+',
+
+    # Dot product (ARMv8.2+)
+    r'vdot[q]?_[a-z0-9_]+',
+
+    # Move
+    r'vmov_[a-z0-9_]+',
+
+    # Across lanes reduction (2-3 cycles)
+    r'v(add|max|min)v[q]?_[a-z0-9_]+',
+]
+
+# Compile patterns for efficiency
+NEON_PATTERNS = [re.compile(p) for p in NEON_INTRINSIC_PATTERNS]
+
+# vreinterpret doesn't generate instructions (type cast only)
+REINTERPRET_PATTERN = re.compile(r'vreinterpret[q]?_[a-z0-9_]+_[a-z0-9_]+')
+
+
+@dataclass
+class IntrinsicAnalysis:
+    """Analysis result for a single intrinsic."""
+    name: str
+    line_start: int
+    line_end: int
+    neon_count: int
+    reinterpret_count: int
+    has_aarch64_path: bool
+    has_armv7_path: bool
+    has_loop: bool
+    has_scalar_fallback: bool
+    body: str = ""
+    tier: int = 0
+    tier_label: str = ""
+    neon_intrinsics: List[str] = field(default_factory=list)
+
+
+def extract_intrinsic_body(lines: List[str], start_idx: int) -> Tuple[str, int]:
+    """Extract the complete function body from starting line."""
+    brace_count = 0
+    started = False
+    body_lines = []
+    end_idx = start_idx
+
+    for i in range(start_idx, len(lines)):
+        line = lines[i]
+        body_lines.append(line)
+
+        for char in line:
+            if char == '{':
+                brace_count += 1
+                started = True
+            elif char == '}':
+                brace_count -= 1
+
+        if started and brace_count == 0:
+            end_idx = i
+            break
+
+    return '\n'.join(body_lines), end_idx
+
+
+def count_neon_intrinsics(body: str) -> Tuple[int, List[str]]:
+    """Count actual NEON intrinsics in function body."""
+    found = []
+
+    # Remove comments
+    body = re.sub(r'//.*$', '', body, flags=re.MULTILINE)
+    body = re.sub(r'/\*.*?\*/', '', body, flags=re.DOTALL)
+
+    for pattern in NEON_PATTERNS:
+        matches = pattern.findall(body)
+        found.extend(matches)
+
+    return len(found), found
+
+
+def count_reinterprets(body: str) -> int:
+    """Count vreinterpret casts (don't generate instructions)."""
+    return len(REINTERPRET_PATTERN.findall(body))
+
+
+def classify_tier(analysis: IntrinsicAnalysis) -> Tuple[int, str]:
+    """Classify intrinsic into performance tier."""
+    n = analysis.neon_count
+
+    # Algorithmic/loop-based implementations
+    if analysis.has_loop:
+        return 4, "T4:algorithmic"
+
+    # Scalar fallbacks are typically slow
+    if analysis.has_scalar_fallback and n == 0:
+        return 4, "T4:scalar"
+
+    # Direct mappings
+    if n <= 2:
+        return 1, "T1:direct"
+
+    # Few operations
+    if n <= 5:
+        return 2, "T2:few_ops"
+
+    # Moderate emulation
+    if n <= 10:
+        return 3, "T3:moderate"
+
+    # Complex emulation
+    return 4, "T4:complex"
+
+
+def analyze_intrinsic(name: str, body: str, line_start: int, line_end: int) -> IntrinsicAnalysis:
+    """Analyze a single intrinsic implementation."""
+    neon_count, neon_list = count_neon_intrinsics(body)
+    reinterpret_count = count_reinterprets(body)
+
+    # Detect loops: look for 'for (' or 'while (' to avoid false matches
+    has_loop = bool(re.search(r'\b(for|while)\s*\(', body))
+
+    # Heuristic to detect scalar fallback implementations:
+    # Look for scalar integer type declarations with assignments that suggest
+    # element-by-element processing (e.g., "uint8_t val = ...").
+    # This may have false positives for loop counters, but effectively identifies
+    # non-vectorized paths in most cases.
+    has_scalar_fallback = bool(re.search(
+        r'\b(u?int(8|16|32|64)_t)\s+\w+\s*=\s*[^;]+;', body
+    )) and neon_count == 0
+
+    analysis = IntrinsicAnalysis(
+        name=name,
+        line_start=line_start,
+        line_end=line_end,
+        neon_count=neon_count,
+        reinterpret_count=reinterpret_count,
+        has_aarch64_path='SSE2NEON_ARCH_AARCH64' in body or '__aarch64__' in body,
+        has_armv7_path='#else' in body and ('SSE2NEON_ARCH_AARCH64' in body or '__aarch64__' in body),
+        has_loop=has_loop,
+        has_scalar_fallback=has_scalar_fallback,
+        body=body,
+        neon_intrinsics=neon_list,
+    )
+
+    analysis.tier, analysis.tier_label = classify_tier(analysis)
+    return analysis
+
+
+def preprocess_with_unifdef(filepath: str) -> Optional[str]:
+    """
+    Preprocess sse2neon.h with unifdef to get AArch64-specific code paths.
+
+    Returns the preprocessed content as a string, or None if unifdef is not available.
+    Note: unifdef may warn about complex macros but still produce usable output.
+    """
+    unifdef_path = shutil.which('unifdef')
+    if not unifdef_path:
+        return None
+
+    try:
+        # Add -b to process complex expressions as blank (keep both branches)
+        # This handles cases like: #if ((__ARM_ARCH == 8) && defined(...))
+        cmd = [unifdef_path, '-b'] + UNIFDEF_AARCH64_FLAGS + [filepath]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        # unifdef returns 0 if output is unmodified, 1 if modified, 2 on error
+        # Even with return code 2, output may be usable (just truncated/partial)
+        if result.stdout and len(result.stdout) > 1000:  # Sanity check
+            return result.stdout
+        else:
+            print(f"Warning: unifdef produced insufficient output", file=sys.stderr)
+            return None
+    except Exception as e:
+        print(f"Warning: unifdef error: {e}", file=sys.stderr)
+        return None
+
+
+def parse_sse2neon(filepath: str, use_unifdef: bool = True) -> List[IntrinsicAnalysis]:
+    """
+    Parse sse2neon.h and analyze all intrinsics.
+
+    Args:
+        filepath: Path to sse2neon.h
+        use_unifdef: If True, preprocess with unifdef for AArch64-specific analysis
+    """
+    content = None
+
+    if use_unifdef:
+        content = preprocess_with_unifdef(filepath)
+        if content:
+            print("Using unifdef for AArch64-specific analysis", file=sys.stderr)
+        else:
+            print("Warning: unifdef not available, analyzing raw file", file=sys.stderr)
+
+    if content is None:
+        with open(filepath, 'r') as f:
+            content = f.read()
+
+    lines = content.split('\n')
+    results = []
+    seen_intrinsics = set()  # Track already-processed intrinsics
+
+    # Match FORCE_INLINE function definitions (implementations only, not forward declarations)
+    # Forward declarations end with ';' while implementations have '{'
+    pattern = re.compile(
+        r'^FORCE_INLINE\s+\S+\s+(_mm\w+)\s*\([^)]*\)\s*\{',
+        re.MULTILINE
+    )
+
+    for match in pattern.finditer(content):
+        name = match.group(1)
+
+        # Skip duplicates (some intrinsics may have multiple #ifdef paths)
+        if name in seen_intrinsics:
+            continue
+        seen_intrinsics.add(name)
+
+        # Find line number (note: line numbers are from preprocessed content)
+        line_start = content[:match.start()].count('\n')
+        body, line_end = extract_intrinsic_body(lines, line_start)
+
+        analysis = analyze_intrinsic(name, body, line_start + 1, line_end + 1)
+        results.append(analysis)
+
+    return results
+
+
+def generate_summary(results: List[IntrinsicAnalysis]) -> Dict:
+    """Generate summary statistics."""
+    tier_counts = defaultdict(int)
+    tier_intrinsics = defaultdict(list)
+
+    for r in results:
+        tier_counts[r.tier] += 1
+        tier_intrinsics[r.tier].append(r.name)
+
+    total = len(results)
+    total_neon = sum(r.neon_count for r in results)
+    total_reinterpret = sum(r.reinterpret_count for r in results)
+
+    return {
+        'total_intrinsics': total,
+        'total_neon_calls': total_neon,
+        'total_reinterprets': total_reinterpret,
+        'avg_neon_per_intrinsic': round(total_neon / total, 2) if total else 0,
+        'tier_distribution': {
+            f'T{i}': {
+                'count': tier_counts[i],
+                'percentage': round(100 * tier_counts[i] / total, 1) if total else 0,
+            }
+            for i in range(1, 5)
+        },
+        'tier_1_examples': tier_intrinsics[1][:10],
+        'tier_4_examples': tier_intrinsics[4][:10],
+    }
+
+
+def print_markdown_report(results: List[IntrinsicAnalysis], summary: Dict):
+    """Print analysis as markdown report."""
+    print("# SSE2NEON Intrinsic Tier Analysis\n")
+    print("## Summary\n")
+    print(f"- **Total Intrinsics**: {summary['total_intrinsics']}")
+    print(f"- **Total NEON Calls**: {summary['total_neon_calls']}")
+    print(f"- **Total vreinterpret Casts**: {summary['total_reinterprets']}")
+    print(f"- **Avg NEON/Intrinsic**: {summary['avg_neon_per_intrinsic']}\n")
+
+    print("## Tier Distribution\n")
+    print("| Tier | Description | Count | % |")
+    print("|------|-------------|-------|---|")
+    tier_desc = {
+        'T1': 'Direct mapping (1-2 ops)',
+        'T2': 'Few operations (3-5 ops)',
+        'T3': 'Moderate emulation (6-10 ops)',
+        'T4': 'Complex/algorithmic (10+ ops)',
+    }
+    for tier, data in summary['tier_distribution'].items():
+        print(f"| {tier} | {tier_desc[tier]} | {data['count']} | {data['percentage']}% |")
+
+    print("\n## Tier Classification Details\n")
+
+    # Group by tier
+    by_tier = defaultdict(list)
+    for r in results:
+        by_tier[r.tier].append(r)
+
+    for tier in range(1, 5):
+        intrinsics = by_tier[tier]
+        if not intrinsics:
+            continue
+
+        print(f"### Tier {tier} ({len(intrinsics)} intrinsics)\n")
+
+        # Show examples
+        examples = sorted(intrinsics, key=lambda x: x.neon_count)[:20]
+        print("| Intrinsic | NEON Ops | Line | Notes |")
+        print("|-----------|----------|------|-------|")
+        for r in examples:
+            notes = []
+            if r.has_aarch64_path:
+                notes.append("AArch64")
+            if r.has_armv7_path:
+                notes.append("ARMv7")
+            if r.has_loop:
+                notes.append("loop")
+            print(f"| `{r.name}` | {r.neon_count} | {r.line_start} | {', '.join(notes)} |")
+        print()
+
+
+def print_json_report(results: List[IntrinsicAnalysis], summary: Dict):
+    """Print analysis as JSON."""
+    output = {
+        'summary': summary,
+        'intrinsics': [
+            {
+                'name': r.name,
+                'tier': r.tier,
+                'tier_label': r.tier_label,
+                'neon_count': r.neon_count,
+                'reinterpret_count': r.reinterpret_count,
+                'line_start': r.line_start,
+                'line_end': r.line_end,
+                'has_aarch64_path': r.has_aarch64_path,
+                'has_armv7_path': r.has_armv7_path,
+                'has_loop': r.has_loop,
+            }
+            for r in results
+        ]
+    }
+    print(json.dumps(output, indent=2))
+
+
+def print_verbose_report(results: List[IntrinsicAnalysis]):
+    """Print detailed verbose report."""
+    for r in sorted(results, key=lambda x: (-x.tier, -x.neon_count)):
+        print(f"\n{'='*60}")
+        print(f"Intrinsic: {r.name}")
+        print(f"Tier: T{r.tier} ({r.tier_label})")
+        print(f"Lines: {r.line_start}-{r.line_end}")
+        print(f"NEON ops: {r.neon_count}, vreinterpret: {r.reinterpret_count}")
+        if r.neon_intrinsics:
+            print(f"NEON intrinsics: {', '.join(set(r.neon_intrinsics)[:10])}")
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Analyze SSE2NEON intrinsic tiers (AArch64-focused)',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+By default, this tool uses unifdef to preprocess sse2neon.h for AArch64,
+removing ARMv7 fallback paths that would inflate instruction counts.
+
+Examples:
+  python3 scripts/analyze-tiers.py              # AArch64 analysis (default)
+  python3 scripts/analyze-tiers.py --no-unifdef # Raw file analysis
+  python3 scripts/analyze-tiers.py --tier 4     # Show T4 (complex) intrinsics
+""")
+    parser.add_argument('--json', action='store_true', help='Output as JSON')
+    parser.add_argument('--markdown', action='store_true', help='Output as Markdown')
+    parser.add_argument('--verbose', action='store_true', help='Verbose output')
+    parser.add_argument('--tier', type=int, help='Filter by tier (1-4)')
+    parser.add_argument('--no-unifdef', action='store_true',
+                        help='Analyze raw file without unifdef preprocessing')
+    parser.add_argument('file', nargs='?', default='sse2neon.h', help='Path to sse2neon.h')
+    args = parser.parse_args()
+
+    # Find sse2neon.h
+    filepath = Path(args.file)
+    if not filepath.exists():
+        # Try relative to script
+        script_dir = Path(__file__).parent.parent
+        filepath = script_dir / 'sse2neon.h'
+
+    if not filepath.exists():
+        print(f"Error: Cannot find sse2neon.h at {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    use_unifdef = not args.no_unifdef
+    results = parse_sse2neon(str(filepath), use_unifdef=use_unifdef)
+
+    if args.tier:
+        results = [r for r in results if r.tier == args.tier]
+
+    summary = generate_summary(results)
+
+    if args.json:
+        print_json_report(results, summary)
+    elif args.verbose:
+        print_verbose_report(results)
+    else:
+        print_markdown_report(results, summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gen-perf-report.py
+++ b/scripts/gen-perf-report.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Generate performance documentation for SSE2NEON.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HEADER = """# SSE2NEON Performance Tier Analysis (AArch64)
+
+This document classifies SSE intrinsics by their NEON implementation complexity
+on AArch64 (ARMv8-A 64-bit). Analysis uses `unifdef` to preprocess conditional
+compilation paths, providing accurate instruction counts for the AArch64 target.
+
+> Note: ARMv7 (32-bit ARM) implementations may differ significantly due to
+> missing instructions like `vrndnq_f32` (directed rounding) and require fallback
+> paths. Use `--no-unifdef` flag to analyze the raw file including all code paths.
+
+To regenerate this file:
+```bash
+python3 scripts/gen-perf-report.py > perf-tier.md
+```
+
+For detailed analysis:
+```bash
+python3 scripts/analyze-tiers.py              # AArch64 analysis (default)
+python3 scripts/analyze-tiers.py --no-unifdef # Raw file (all architectures)
+python3 scripts/analyze-tiers.py --json       # JSON output
+python3 scripts/analyze-tiers.py --tier 4     # Filter by tier
+```
+
+---
+"""
+
+
+def main():
+    # Run analyze_tiers.py and get JSON output
+    script_dir = Path(__file__).parent
+    result = subprocess.run(
+        [sys.executable, str(script_dir / 'analyze-tiers.py'), '--json'],
+        capture_output=True, text=True
+    )
+
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(result.stdout)
+    # Use all intrinsics - analyze_tiers.py already filters to _mm* functions
+    intrinsics = data['intrinsics']
+
+    # Print header with regeneration instructions
+    print(HEADER)
+    print('## SSE2NEON Performance Classification (AArch64)')
+    print()
+    print('Based on static analysis of NEON instruction counts per SSE intrinsic.')
+    print('Cycle estimates based on ARM Cortex-A72 (ARMv8-A) Software Optimization Guide.')
+    print()
+
+    # Summary table
+    print('### Summary')
+    print()
+    print('| Metric | Value |')
+    print('|--------|-------|')
+    print(f'| Total SSE Intrinsics | {len(intrinsics)} |')
+
+    t1_count = sum(1 for i in intrinsics if i['tier'] == 1)
+    t23_count = sum(1 for i in intrinsics if i['tier'] in [2, 3])
+    t4_count = sum(1 for i in intrinsics if i['tier'] == 4)
+
+    print(f'| Direct Mappings (T1) | {t1_count} ({100*t1_count/len(intrinsics):.1f}%) |')
+    print(f'| Moderate Emulation (T2-T3) | {t23_count} ({100*t23_count/len(intrinsics):.1f}%) |')
+    print(f'| Complex Emulation (T4) | {t4_count} ({100*t4_count/len(intrinsics):.1f}%) |')
+
+    avg_neon = sum(i['neon_count'] for i in intrinsics) / len(intrinsics)
+    print(f'| Avg NEON Ops/Intrinsic | {avg_neon:.2f} |')
+    print()
+
+    # Tier explanation
+    print('### Performance Tiers')
+    print()
+    print('| Tier | NEON Ops | Estimated Cycles | Description |')
+    print('|------|----------|------------------|-------------|')
+    print('| T1 | 1-2 | 1-3 | Direct NEON mapping, near-native performance |')
+    print('| T2 | 3-5 | 4-8 | Few NEON operations, slight overhead |')
+    print('| T3 | 6-10 | 8-15 | Moderate emulation, noticeable overhead |')
+    print('| T4 | 10+ | 15-50+ | Complex/algorithmic, significant overhead |')
+    print()
+
+    # Hot intrinsics to watch
+    print('### Performance-Critical Intrinsics (T4)')
+    print()
+    print('These intrinsics have significant emulation overhead. Consider alternative')
+    print('algorithms when porting performance-critical code.')
+    print()
+    print('| Intrinsic | NEON Ops | Notes |')
+    print('|-----------|----------|-------|')
+
+    t4 = sorted([i for i in intrinsics if i['tier'] == 4], key=lambda x: -x['neon_count'])
+    for item in t4[:15]:
+        name = item['name']
+        neon = item['neon_count']
+        notes = []
+        if 'aes' in name.lower():
+            notes.append('Use HW crypto when available')
+        elif 'mpsadbw' in name:
+            notes.append('SAD computation, very expensive')
+        elif 'round' in name:
+            notes.append('Rounding modes emulation')
+        elif 'rsqrt' in name or 'sqrt' in name:
+            notes.append('Newton-Raphson refinement')
+        elif 'crc' in name:
+            notes.append('Use HW CRC when available')
+        elif 'clmul' in name:
+            notes.append('Carryless multiply')
+        elif 'madd' in name:
+            notes.append('Multiply-add with widening')
+        elif 'minpos' in name:
+            notes.append('Horizontal minimum search')
+        print(f'| `{name}` | {neon} | {" ".join(notes)} |')
+
+    print()
+    print('### Efficient Intrinsics (T1 - Single NEON Instruction)')
+    print()
+    print('These intrinsics map directly to single NEON instructions:')
+    print()
+
+    t1_one = sorted([i for i in intrinsics if i['tier'] == 1 and i['neon_count'] == 1],
+                    key=lambda x: x['name'])
+
+    # Group by category
+    categories = {
+        'Arithmetic': ['add', 'sub', 'mul', 'div', 'neg', 'abs'],
+        'Comparison': ['cmpeq', 'cmpgt', 'cmplt', 'test'],
+        'Logical': ['and', 'or', 'xor', 'not'],
+        'Load/Store': ['load', 'store', 'set', 'get'],
+        'Conversion': ['cvt', 'cast'],
+        'Math': ['sqrt', 'ceil', 'floor', 'round', 'min', 'max'],
+    }
+
+    for cat, keywords in categories.items():
+        items = [i['name'] for i in t1_one if any(k in i['name'].lower() for k in keywords)]
+        if items:
+            display = ', '.join(f'`{n}`' for n in items[:8])
+            if len(items) > 8:
+                display += f', ... (+{len(items)-8} more)'
+            print(f'- {cat}: {display}')
+
+    # Full tier breakdown
+    print()
+    print('### Complete Tier Classification')
+    print()
+    print('<details>')
+    print('<summary>Click to expand full list</summary>')
+    print()
+
+    for tier in range(1, 5):
+        tier_items = sorted([i for i in intrinsics if i['tier'] == tier], key=lambda x: x['name'])
+        print(f'#### Tier {tier} ({len(tier_items)} intrinsics)')
+        print()
+        if tier_items:
+            # Show as compact list
+            names = [f'`{i["name"]}`' for i in tier_items]
+            # Wrap at ~80 chars
+            line = ''
+            for name in names:
+                if len(line) + len(name) > 75:
+                    print(line)
+                    line = name
+                else:
+                    line = line + ', ' + name if line else name
+            if line:
+                print(line)
+        print()
+
+    print('</details>')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This introduces static analysis tools to classify SSE intrinsics by their NEON implementation complexity:
- scripts/analyze-tiers.py: Counts NEON instructions per intrinsic
- scripts/gen-perf-report.py: Generates markdown documentation
- perf-tier.md: Performance tier classification (T1-T4)

Tier distribution:
  T1=325 (65.7%), T2=123 (24.8%), T3=29 (5.9%), T4=18 (3.6%)









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds performance tier analysis for SSE2NEON and an auto-generated report classifying intrinsics by NEON implementation complexity (T1–T4). Includes a CI check that reminds to regenerate perf-tier.md when it’s out of sync.

- **New Features**
  - Added scripts/analyze-tiers.py and scripts/gen-perf-report.py to count NEON ops per intrinsic and generate perf-tier.md.
  - Added perf-tier.md with tier definitions and full classification; distribution: T1=341 (74.9%), T2=99 (21.8%), T3=10 (2.2%), T4=5 (1.1%).
  - Added perf-tier-check GitHub Action running .ci/check-perf-tier.sh; posts a reminder comment on PRs if perf-tier.md is out of sync.
  - Updated README to link to perf-tier.md and corrected _mm_maddubs_epi16 to 13 NEON ops.

<sup>Written for commit 0cf55e23ad11c00db73c21f59a7e47843f1b6079. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









