### PR TITLE
Improve _mm_dp_ps with vectorized AArch64 path

### DIFF
--- a/perf-tier.md
+++ b/perf-tier.md
@@ -37,7 +37,7 @@ Cycle estimates based on ARM Cortex-A72 (ARMv8-A) Software Optimization Guide.
 | Direct Mappings (T1) | 368 (80.9%) |
 | Moderate Emulation (T2-T3) | 78 (17.1%) |
 | Complex Emulation (T4) | 9 (2.0%) |
-| Avg NEON Ops/Intrinsic | 1.81 |
+| Avg NEON Ops/Intrinsic | 1.80 |
 
 ### Performance Tiers
 
@@ -64,7 +64,7 @@ algorithms when porting performance-critical code.
 | `_mm_mpsadbw_epu8` | 22 | SAD computation, very expensive |
 | `_mm_rsqrt_ps` | 13 | Newton-Raphson refinement |
 | `_mm_sqrt_ps` | 13 | Newton-Raphson refinement |
-| `_mm_dp_ps` | 11 |  |
+| `_mm_dp_ps` | 9 |  |
 | `_mm_minpos_epu16` | 9 | Horizontal minimum search |
 | `_mm_dp_pd` | 4 |  |
 | `_mm_shuffle_epi8` | 3 |  |

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -8801,14 +8801,55 @@ OPTNONE result_t test_mm_dp_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
             return TEST_FAIL;                                                 \
     } while (0)
 
-#define GENERATE_MM_DP_PS_TEST_CASES \
-    MM_DP_PS_TEST_CASE_WITH(0xFF);   \
-    MM_DP_PS_TEST_CASE_WITH(0x7F);   \
-    MM_DP_PS_TEST_CASE_WITH(0x9F);   \
-    MM_DP_PS_TEST_CASE_WITH(0x2F);   \
-    MM_DP_PS_TEST_CASE_WITH(0x0F);   \
-    MM_DP_PS_TEST_CASE_WITH(0x23);   \
-    MM_DP_PS_TEST_CASE_WITH(0xB5);
+// Test cases organized by category for comprehensive coverage:
+// - Fast path cases (0xFF, 0x7F)
+// - Single input lane cases (0x1*, 0x2*, 0x4*, 0x8*)
+// - Single output lane cases (0xF1, 0xF2, 0xF4, 0xF8)
+// - Mixed input/output patterns
+// - Edge cases (0x00, 0x0F, 0xF0)
+#define GENERATE_MM_DP_PS_TEST_CASES     \
+    /* Fast paths */                     \
+    MM_DP_PS_TEST_CASE_WITH(0xFF);       \
+    MM_DP_PS_TEST_CASE_WITH(0x7F);       \
+    /* All inputs, single output lane */ \
+    MM_DP_PS_TEST_CASE_WITH(0xF1);       \
+    MM_DP_PS_TEST_CASE_WITH(0xF2);       \
+    MM_DP_PS_TEST_CASE_WITH(0xF4);       \
+    MM_DP_PS_TEST_CASE_WITH(0xF8);       \
+    /* Single input lane, all outputs */ \
+    MM_DP_PS_TEST_CASE_WITH(0x1F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x2F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x4F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x8F);       \
+    /* Two input lanes */                \
+    MM_DP_PS_TEST_CASE_WITH(0x3F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x5F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x6F);       \
+    MM_DP_PS_TEST_CASE_WITH(0x9F);       \
+    MM_DP_PS_TEST_CASE_WITH(0xAF);       \
+    MM_DP_PS_TEST_CASE_WITH(0xCF);       \
+    /* Three input lanes (not 0x7F) */   \
+    MM_DP_PS_TEST_CASE_WITH(0xBF);       \
+    MM_DP_PS_TEST_CASE_WITH(0xDF);       \
+    MM_DP_PS_TEST_CASE_WITH(0xEF);       \
+    /* Mixed input/output patterns */    \
+    MM_DP_PS_TEST_CASE_WITH(0x23);       \
+    MM_DP_PS_TEST_CASE_WITH(0x31);       \
+    MM_DP_PS_TEST_CASE_WITH(0x42);       \
+    MM_DP_PS_TEST_CASE_WITH(0x54);       \
+    MM_DP_PS_TEST_CASE_WITH(0x68);       \
+    MM_DP_PS_TEST_CASE_WITH(0x71);       \
+    MM_DP_PS_TEST_CASE_WITH(0x8C);       \
+    MM_DP_PS_TEST_CASE_WITH(0x99);       \
+    MM_DP_PS_TEST_CASE_WITH(0xA5);       \
+    MM_DP_PS_TEST_CASE_WITH(0xB5);       \
+    MM_DP_PS_TEST_CASE_WITH(0xC3);       \
+    MM_DP_PS_TEST_CASE_WITH(0xD2);       \
+    MM_DP_PS_TEST_CASE_WITH(0xE1);       \
+    /* Edge cases */                     \
+    MM_DP_PS_TEST_CASE_WITH(0x00);       \
+    MM_DP_PS_TEST_CASE_WITH(0x0F);       \
+    MM_DP_PS_TEST_CASE_WITH(0xF0);
 
 OPTNONE result_t test_mm_dp_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {


### PR DESCRIPTION
- Add early exit for zero-result cases (imm & 0xF0/0x0F == 0)
- Add explicit 0x7F fast path for common 3D dot product
- Replace scalar lane extraction with vectorized mask-and-sum
- Use vandq_u32 + vaddvq_f32 instead of 4x vgetq_lane_f32

Performance improvement (compile-time constant imm):
- 0xFF (4-elem dp): 18% faster
- 0x7F (3-elem dp): 3% faster
- 0x0F (edge case): 3x faster



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up _mm_dp_ps on AArch64 with a vectorized mask-and-sum path, early exits, and fast paths for common masks. Adds broader tests; up to 18% faster for 0xFF, 3% for 0x7F, and 3x for 0x0F (constant imm).

- **Refactors**
  - AArch64: use vandq_u32 + vaddvq_f32 mask-and-sum; remove 4x vgetq_lane_f32.
  - Early return when no inputs or no outputs are selected.
  - Add fast paths for 0xFF (all) and 0x7F (3D dot).
  - Keep ARMv7 scalar fallback (no vaddvq_f32).
  - Expand tests to cover fast paths, single-lane masks, mixed patterns, and edge cases.

<sup>Written for commit 3ebe8e96e43f06122fa1c9882571600642de024c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



