### PR TITLE
Fix strict aliasing violations in ARMv7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,6 +146,31 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: make SANITIZE=${{ matrix.sanitizer }} check
 
+  strict-aliasing:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        arch: [armv7, aarch64]
+        cxx_compiler: [g++, clang++-18]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: build and test with strict aliasing
+        uses: uraimo/run-on-arch-action@v3
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu24.04
+          githubToken: ${{ github.token }}
+          env: |
+            CXX: ${{ matrix.cxx_compiler }}
+          install: |
+            rm -rf /var/lib/apt/lists/*
+            apt-get -o Acquire::Retries=5 update
+            apt-get -o Acquire::Retries=5 -o Dpkg::Use-Pty=0 install -y --no-install-recommends clang-18 gcc g++ make
+            apt-get clean && rm -rf /var/lib/apt/lists/*
+          run: |
+            make STRICT_ALIASING=1 check
+
   static-analysis:
     runs-on: ubuntu-24.04
     env:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,15 @@ else
 SANITIZE_FLAGS =
 endif
 
-CXXFLAGS += -Wall -Wcast-qual -Wold-style-cast -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14 $(SANITIZE_FLAGS)
+# Strict aliasing checking: STRICT_ALIASING=1 to enable
+STRICT_ALIASING ?=
+ifneq ($(STRICT_ALIASING),)
+STRICT_ALIASING_FLAGS = -fstrict-aliasing -Wstrict-aliasing=2
+else
+STRICT_ALIASING_FLAGS =
+endif
+
+CXXFLAGS += -Wall -Wcast-qual -Wold-style-cast -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14 $(SANITIZE_FLAGS) $(STRICT_ALIASING_FLAGS)
 LDFLAGS  += -lm $(SANITIZE_FLAGS)
 OBJS = \
     tests/binding.o \
@@ -127,7 +135,11 @@ indent:
 check-ubsan: clean
 	$(MAKE) SANITIZE=undefined check
 
-.PHONY: clean check check-ubsan format floatpoint
+# Convenience target for running tests with strict aliasing checks
+check-strict-aliasing: clean
+	$(MAKE) STRICT_ALIASING=1 check
+
+.PHONY: clean check check-ubsan check-strict-aliasing format floatpoint
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps) sse2neon.h.gch
 	$(RM) $(FLOATPOINT_OBJS) $(FLOATPOINT_EXEC) $(floatpoint_deps)

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -738,6 +738,17 @@ FORCE_INLINE int _sse2neon_isinf_f64(double v)
     return (u.u & 0x7FFFFFFFFFFFFFFFULL) == 0x7FF0000000000000ULL;
 }
 
+/* Safe helper to load double[2] as float32x4_t without strict aliasing
+ * violation. Used in ARMv7 fallback paths where float64x2_t is not natively
+ * supported.
+ */
+FORCE_INLINE float32x4_t sse2neon_vld1q_f32_from_f64pair(const double *p)
+{
+    float32x4_t tmp;
+    memcpy(&tmp, p, sizeof(tmp));
+    return tmp;
+}
+
 /* Safe float/double to integer conversion with x86 SSE semantics.
  * x86 SSE returns the "integer indefinite" value (0x80000000 for int32,
  * 0x8000000000000000 for int64) for all out-of-range conversions including
@@ -3255,7 +3266,7 @@ FORCE_INLINE __m128d _mm_add_pd(__m128d a, __m128d b)
     double c[2];
     c[0] = a0 + b0;
     c[1] = a1 + b1;
-    return vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c));
+    return sse2neon_vld1q_f32_from_f64pair(c);
 #endif
 }
 
@@ -3275,7 +3286,7 @@ FORCE_INLINE __m128d _mm_add_sd(__m128d a, __m128d b)
     double c[2];
     c[0] = a0 + b0;
     c[1] = a1;
-    return vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c));
+    return sse2neon_vld1q_f32_from_f64pair(c);
 #endif
 }
 
@@ -4560,7 +4571,7 @@ FORCE_INLINE __m128d _mm_div_pd(__m128d a, __m128d b)
     double c[2];
     c[0] = a0 / b0;
     c[1] = a1 / b1;
-    return vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c));
+    return sse2neon_vld1q_f32_from_f64pair(c);
 #endif
 }
 
@@ -4840,8 +4851,7 @@ FORCE_INLINE __m128d _mm_max_sd(__m128d a, __m128d b)
     a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
     b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
     double c[2] = {a0 > b0 ? a0 : b0, a1};
-    return vreinterpretq_m128d_f32(
-        vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c)));
+    return vreinterpretq_m128d_f32(sse2neon_vld1q_f32_from_f64pair(c));
 #endif
 }
 
@@ -4907,8 +4917,7 @@ FORCE_INLINE __m128d _mm_min_sd(__m128d a, __m128d b)
     a1 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(a), 1));
     b0 = sse2neon_recast_u64_f64(vgetq_lane_u64(vreinterpretq_u64_m128d(b), 0));
     double c[2] = {a0 < b0 ? a0 : b0, a1};
-    return vreinterpretq_m128d_f32(
-        vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c)));
+    return vreinterpretq_m128d_f32(sse2neon_vld1q_f32_from_f64pair(c));
 #endif
 }
 
@@ -5067,7 +5076,7 @@ FORCE_INLINE __m128d _mm_mul_pd(__m128d a, __m128d b)
     double c[2];
     c[0] = a0 * b0;
     c[1] = a1 * b1;
-    return vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c));
+    return sse2neon_vld1q_f32_from_f64pair(c);
 #endif
 }
 
@@ -5297,8 +5306,7 @@ FORCE_INLINE __m128d _mm_set_pd(double e1, double e0)
     return vreinterpretq_m128d_f64(
         vld1q_f64(_sse2neon_reinterpret_cast(float64_t *, data)));
 #else
-    return vreinterpretq_m128d_f32(
-        vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, data)));
+    return vreinterpretq_m128d_f32(sse2neon_vld1q_f32_from_f64pair(data));
 #endif
 }
 
@@ -6067,7 +6075,7 @@ FORCE_INLINE __m128d _mm_sub_pd(__m128d a, __m128d b)
     double c[2];
     c[0] = a0 - b0;
     c[1] = a1 - b1;
-    return vld1q_f32(_sse2neon_reinterpret_cast(float32_t *, c));
+    return sse2neon_vld1q_f32_from_f64pair(c);
 #endif
 }
 


### PR DESCRIPTION
This adds sse2neon_vld1q_f32_from_f64pair helper using memcpy to safely load double[2] arrays as float32x4_t without violating C/C++ strict aliasing rules. This follows the established pattern from commit 6e6a265 which introduced sse2neon_recast_* helpers.

The original code cast double* to float32_t* for vld1q_f32, which is undefined behavior under strict aliasing. With -fstrict-aliasing at -O2/-O3, compilers may misoptimize assuming these pointers do not alias.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes strict aliasing undefined behavior in ARMv7 paths by replacing unsafe double*→float32_t* casts with a memcpy-based loader. Adds build flags and CI jobs to catch aliasing issues under -fstrict-aliasing on armv7 and aarch64.

- **Bug Fixes**
  - Added sse2neon_vld1q_f32_from_f64pair (memcpy-based) for safely loading double[2] into float32x4_t.
  - Updated ARMv7 fallback implementations of _mm_add_pd/_mm_add_sd/_mm_div_pd/_mm_mul_pd/_mm_sub_pd/_mm_set_pd/_mm_max_sd/_mm_min_sd to use the helper.

- **Migration**
  - To verify locally: make check-strict-aliasing or make STRICT_ALIASING=1 check.

<sup>Written for commit 95c7197e9a4c153c20204b377beea27a85b2dc80. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

