### PR TITLE
Optimize _mm_crc32_u32 on Armv8-A 32-bit platform

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -9400,6 +9400,8 @@ FORCE_INLINE uint32_t _mm_crc32_u32(uint32_t crc, uint32_t v)
 #elif ((__ARM_ARCH == 8) && defined(__ARM_FEATURE_CRC32)) || \
     ((defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(__clang__))
     crc = __crc32cw(crc, v);
+#elif defined(__ARM_FEATURE_CRYPTO)
+    SSE2NEON_CRC32C_BASE(crc, v, 32);
 #else
     crc = _mm_crc32_u16(crc, _sse2neon_static_cast(uint16_t, v & 0xffff));
     crc =


### PR DESCRIPTION
Optimize `_mm_crc32_u32()` on Armv8-A 32-bit platform using Barrett reduction shortcut.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized _mm_crc32_u32 for Armv8-A 32-bit by adding a fast Barrett reduction path when __ARM_FEATURE_CRYPTO is available. This speeds up CRC computation on devices without the CRC32 instruction by replacing the slow u16/u8 fallback.

<sup>Written for commit cf243af47d1495898156d2ce031a37e27e382b7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

