### PR TITLE
Remove obsolete optimization warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Define these macros as `1` before including `sse2neon.h` to enable precise (but 
 | `SSE2NEON_PRECISE_DIV` | Extra Newton-Raphson iteration for `_mm_rcp_ps` and `_mm_div_ps` |
 | `SSE2NEON_PRECISE_SQRT` | Extra Newton-Raphson iteration for `_mm_sqrt_ps` and `_mm_rsqrt_ps` |
 | `SSE2NEON_PRECISE_DP` | Conditional multiplication in `_mm_dp_pd` |
-| `SSE2NEON_SUPPRESS_WARNINGS` | Disable optimization-enabled warnings |
 
 All flags are disabled by default to maximize performance.
 

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -238,11 +238,6 @@
 #pragma message("Macro name collisions may happen with unsupported compilers.")
 #endif
 
-#if defined(__OPTIMIZE__) && !defined(SSE2NEON_SUPPRESS_WARNINGS)
-#warning \
-    "Report any potential compiler optimization issues when using SSE2NEON. See the 'Optimization' section at https://github.com/DLTcollab/sse2neon."
-#endif
-
 /* C language does not allow initializing a variable with a function call. */
 #ifdef __cplusplus
 #define _sse2neon_const static const


### PR DESCRIPTION
The `#warning` about optimization issues was added when sse2neon supported older compilers with known vector codegen bugs. Now that GCC 10+ and Clang 11+ are enforced via #error, this warning fires on every optimized build with known-good toolchains, providing no diagnostic value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the obsolete optimization #warning that fired on every optimized build with supported compilers. GCC 10+ and Clang 11+ are enforced via #error, so the warning and the SSE2NEON_SUPPRESS_WARNINGS flag (removed from README) are no longer needed.

<sup>Written for commit 4126b4b9bbc165cbd33f8c227c9c68bdd68e6c7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

