### PR TITLE
Fix typo in _mm_movehl_ps architecture check

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2371,7 +2371,7 @@ FORCE_INLINE __m128 _mm_move_ss(__m128 a, __m128 b)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_movehl_ps
 FORCE_INLINE __m128 _mm_movehl_ps(__m128 a, __m128 b)
 {
-#if defined(aarch64__)
+#if SSE2NEON_ARCH_AARCH64
     return vreinterpretq_m128_u64(
         vzip2q_u64(vreinterpretq_u64_m128(b), vreinterpretq_u64_m128(a)));
 #else


### PR DESCRIPTION
The macro check 'defined(aarch64__)' was missing a leading underscore, causing AArch64 platforms to incorrectly use the slower ARMv7 fallback path. Replace with `SSE2NEON_ARCH_AARCH64` for consistency with the rest of the codebase and proper cross-compiler support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the AArch64 architecture check in _mm_movehl_ps by using SSE2NEON_ARCH_AARCH64, so AArch64 uses the NEON path instead of the ARMv7 fallback. Aligns macro usage with the rest of the codebase and improves cross-compiler support.

<sup>Written for commit 84724660e0bb38a4abfc8e713031b77ef0f6654b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

