### PR TITLE
Add compile-time guard for little-endian requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Enable the compile-time precision flags below when exact SSE compatibility is re
 
 ## Requirements
 
-Use GCC 10+ or Clang 11+.
+**Architecture**: Little-endian ARM only. Big-endian ARM is not supported and will produce a compile-time error.
+
+**Compilers**: Use GCC 10+ or Clang 11+.
 Earlier compiler versions contain bugs in vector instruction generation that cause incorrect assembly output for certain NEON intrinsics (e.g., `rev16`, `rev32` with invalid operand combinations).
 
 ## Usage

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -232,6 +232,23 @@
 #define SSE2NEON_ARCH_AARCH64 0
 #endif
 
+/* Endianness check
+ *
+ * SSE2NEON assumes little-endian byte ordering for lane-to-memory mappings.
+ * Big-endian ARM targets would produce silently incorrect results because
+ * SSE intrinsics define lane ordering relative to little-endian memory layout.
+ *
+ * GCC/Clang define __BYTE_ORDER__. For compilers that don't (e.g., MSVC),
+ * we check for explicit big-endian ARM macros. MSVC only targets little-endian
+ * ARM, so no additional check is needed there.
+ */
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
+#error "sse2neon requires little-endian target; big-endian is not supported"
+#elif defined(__ARMEB__) || defined(__AARCH64EB__) || \
+    defined(__BIG_ENDIAN__) || defined(_BIG_ENDIAN)
+#error "sse2neon requires little-endian target; big-endian is not supported"
+#endif
+
 /* compiler specific definitions */
 #if SSE2NEON_COMPILER_GCC_COMPAT
 #pragma push_macro("FORCE_INLINE")


### PR DESCRIPTION
SSE intrinsics assume little-endian lane ordering. Big-endian ARM targets would silently produce incorrect results. This adds a compile-time #error to catch unsupported configurations early.

The guard uses __BYTE_ORDER__ (GCC/Clang) with fallback checks for explicit big-endian macros (`__ARMEB__`, `__AARCH64EB__`, `__BIG_ENDIAN__`, `_BIG_ENDIAN`) to cover compilers that don't define `__BYTE_ORDER__`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a compile-time endianness guard to enforce little-endian ARM; big-endian builds now fail early to prevent incorrect results. Detection uses __BYTE_ORDER__ with fallbacks for common big-endian macros, and the README documents the requirement.

<sup>Written for commit 26b9a45d6a090a0fe5defd003786a96a67c344b6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



