### PR TITLE
Fix -Wconversion warnings in SSE4.2

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -8593,7 +8593,8 @@ static uint16_t _sse2neon_aggregate_ranges_16x8(int la, int lb, __m128i mtx[16])
         uint16x8_t masked = vandq_u16(vec, vreinterpretq_u16_m128i(mtx[i])); \
         uint16x8_t swapped = vrev32q_u16(masked);                            \
         uint16x8_t pair_and = vandq_u16(masked, swapped);                    \
-        res |= (vmaxvq_u16(pair_and) ? 1U : 0U) << (i);                      \
+        res |= _sse2neon_static_cast(uint16_t,                               \
+                                     (vmaxvq_u16(pair_and) ? 1U : 0U) << i); \
     } while (0)
 
     uint16_t res = 0;
@@ -8652,12 +8653,13 @@ static uint16_t _sse2neon_aggregate_ranges_8x16(int la, int lb, __m128i mtx[16])
      * 3. Pair-AND: AND original with swapped to get [b0&b1, b0&b1, ...]
      * 4. Horizontal OR via vmaxvq_u8 (faster than vmaxvq_u16)
      */
-#define SSE2NEON_RANGES_MATCH8(i)                                          \
-    do {                                                                   \
-        uint8x16_t masked = vandq_u8(vec, vreinterpretq_u8_m128i(mtx[i])); \
-        uint8x16_t swapped = vrev16q_u8(masked);                           \
-        uint8x16_t pair_and = vandq_u8(masked, swapped);                   \
-        res |= (vmaxvq_u8(pair_and) ? 1U : 0U) << (i);                     \
+#define SSE2NEON_RANGES_MATCH8(i)                                              \
+    do {                                                                       \
+        uint8x16_t masked = vandq_u8(vec, vreinterpretq_u8_m128i(mtx[i]));     \
+        uint8x16_t swapped = vrev16q_u8(masked);                               \
+        uint8x16_t pair_and = vandq_u8(masked, swapped);                       \
+        res |= _sse2neon_static_cast(uint16_t, (vmaxvq_u8(pair_and) ? 1U : 0U) \
+                                                   << i);                      \
     } while (0)
 
     uint16_t res = 0;


### PR DESCRIPTION
This adds explicit uint16_t casts in SSE2NEON_RANGES_MATCH16 and SSE2NEON_RANGES_MATCH8 macros to silence GCC -Wconversion warnings. The expression (1U << i) produces unsigned int, which triggers warnings when assigned to uint16_t via compound assignment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences GCC -Wconversion warnings in the SSE4.2 range-match macros by casting the shifted flag to uint16_t before OR-ing into res. Updates SSE2NEON_RANGES_MATCH16 and SSE2NEON_RANGES_MATCH8; no functional change.

<sup>Written for commit 659ed755287be54e67d876d88e1b35d9214c9783. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

