### PR TITLE
Fix parenthesis mismatch in CRC32C crypto fallback

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -9478,16 +9478,17 @@ FORCE_INLINE __m128i _mm_cmpgt_epi64(__m128i a, __m128i b)
  * 5. Extract the lower (in bit-reflected sense) 32 bits in the upper half of
  *    'tmp'.
  */
-#define SSE2NEON_CRC32C_BASE(crc, v, bit)                                                      \
-    do {                                                                                       \
-        crc ^= v;                                                                              \
-    uint64x2_t orig = vcombine_u64(vcreate_u64((uint64_t) (crc) << ((bit)), vcreate_u64(0x0)); \
-    uint64x2_t tmp = orig; \
-    uint64_t p = 0x105EC76F1; \
-    uint64_t mu = 0x1dea713f1; \
-    tmp = _sse2neon_vmull_p64(vget_low_u64(tmp), vcreate_u64(mu)); \
-    tmp = _sse2neon_vmull_p64(vget_high_u64(tmp), vcreate_u64(p)); \
-    crc = vgetq_lane_u32(vreinterpretq_u32_u64(tmp), 2);                                       \
+#define SSE2NEON_CRC32C_BASE(crc, v, bit)                                      \
+    do {                                                                       \
+        crc ^= v;                                                              \
+        uint64x2_t orig = vcombine_u64(vcreate_u64((uint64_t) (crc) << (bit)), \
+                                       vcreate_u64(0x0));                      \
+        uint64x2_t tmp = orig;                                                 \
+        uint64_t p = 0x105EC76F1;                                              \
+        uint64_t mu = 0x1dea713f1;                                             \
+        tmp = _sse2neon_vmull_p64(vget_low_u64(tmp), vcreate_u64(mu));         \
+        tmp = _sse2neon_vmull_p64(vget_high_u64(tmp), vcreate_u64(p));         \
+        crc = vgetq_lane_u32(vreinterpretq_u32_u64(tmp), 2);                   \
     } while (0)
 
 // Starting with the initial value in crc, accumulates a CRC32 value for


### PR DESCRIPTION
SSE2NEON_CRC32C_BASE had a syntax error: vcombine_u64() was missing a closing parenthesis for its first vcreate_u64() argument.

Before: `vcreate_u64((uint64_t) (crc) << ((bit)), vcreate_u64(0x0))`
After:  `vcreate_u64((uint64_t) (crc) << (bit)), vcreate_u64(0x0)`

This path is used when `__ARM_FEATURE_CRYPTO` is available but `__ARM_FEATURE_CRC32` is not (Barrett reduction via CLMUL).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a parenthesis mismatch in SSE2NEON_CRC32C_BASE that caused compile errors in the CRC32C crypto fallback on ARM. This path now builds when __ARM_FEATURE_CRYPTO is present but __ARM_FEATURE_CRC32 is not.

- **Bug Fixes**
  - Closed the first vcreate_u64(...) argument in the vcombine_u64(...) call.
  - No behavior change; fixes build for the CLMUL (Barrett reduction) path.

<sup>Written for commit 424d88bbb0fa9d9b3962d580807e021408fe5b00. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

