### PR TITLE
Fix float-to-integer conversion saturation for x86

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -867,6 +867,27 @@ FORCE_INLINE int64_t _sse2neon_cvtf_s64(float v)
     return _sse2neon_static_cast(int64_t, v);
 }
 
+/* Vectorized helper: apply x86 saturation semantics to NEON conversion result.
+ * ARM returns 0 for NaN and INT32_MAX for positive overflow, but x86 returns
+ * INT32_MIN ("integer indefinite") for both. This function fixes up the result.
+ */
+FORCE_INLINE int32x4_t _sse2neon_cvtps_epi32_fixup(float32x4_t f, int32x4_t cvt)
+{
+    /* Detect values >= 2147483648.0f (out of INT32 range) */
+    float32x4_t max_f = vdupq_n_f32(2147483648.0f);
+    uint32x4_t overflow = vcgeq_f32(f, max_f);
+
+    /* Detect NaN: x != x for NaN values */
+    uint32x4_t is_nan = vmvnq_u32(vceqq_f32(f, f));
+
+    /* Combine: any overflow or NaN should produce INT32_MIN */
+    uint32x4_t need_indefinite = vorrq_u32(overflow, is_nan);
+
+    /* Blend: select INT32_MIN where needed */
+    int32x4_t indefinite = vdupq_n_s32(INT32_MIN);
+    return vbslq_s32(need_indefinite, indefinite, cvt);
+}
+
 /* SSE macros */
 #define _MM_GET_FLUSH_ZERO_MODE _sse2neon_mm_get_flush_zero_mode
 #define _MM_SET_FLUSH_ZERO_MODE _sse2neon_mm_set_flush_zero_mode
@@ -2047,16 +2068,19 @@ FORCE_INLINE int64_t _mm_cvtss_si64(__m128 a)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtt_ps2pi
 FORCE_INLINE __m64 _mm_cvtt_ps2pi(__m128 a)
 {
-    return vreinterpret_m64_s32(
-        vget_low_s32(vcvtq_s32_f32(vreinterpretq_f32_m128(a))));
+    float32x4_t f = vreinterpretq_f32_m128(a);
+    int32x4_t cvt = vcvtq_s32_f32(f);
+    int32x4_t result = _sse2neon_cvtps_epi32_fixup(f, cvt);
+    return vreinterpret_m64_s32(vget_low_s32(result));
 }
 
 // Convert the lower single-precision (32-bit) floating-point element in a to a
 // 32-bit integer with truncation, and store the result in dst.
+// x86 returns INT32_MIN for NaN and out-of-range values.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtt_ss2si
 FORCE_INLINE int _mm_cvtt_ss2si(__m128 a)
 {
-    return vgetq_lane_s32(vcvtq_s32_f32(vreinterpretq_f32_m128(a)), 0);
+    return _sse2neon_cvtf_s32(vgetq_lane_f32(vreinterpretq_f32_m128(a), 0));
 }
 
 // Convert packed single-precision (32-bit) floating-point elements in a to
@@ -2071,11 +2095,11 @@ FORCE_INLINE int _mm_cvtt_ss2si(__m128 a)
 
 // Convert the lower single-precision (32-bit) floating-point element in a to a
 // 64-bit integer with truncation, and store the result in dst.
+// x86 returns INT64_MIN for NaN and out-of-range values.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttss_si64
 FORCE_INLINE int64_t _mm_cvttss_si64(__m128 a)
 {
-    return _sse2neon_static_cast(int64_t,
-                                 vgetq_lane_f32(vreinterpretq_f32_m128(a), 0));
+    return _sse2neon_cvtf_s64(vgetq_lane_f32(vreinterpretq_f32_m128(a), 0));
 }
 
 // Divide packed single-precision (32-bit) floating-point elements in a by
@@ -4324,58 +4348,68 @@ FORCE_INLINE __m128d _mm_cvtpi32_pd(__m64 a)
 
 // Convert packed single-precision (32-bit) floating-point elements in a to
 // packed 32-bit integers, and store the results in dst.
+// x86 returns INT32_MIN ("integer indefinite") for NaN and out-of-range values.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvtps_epi32
 // *NOTE*. The default rounding mode on SSE is 'round to even', which ARMv7-A
 // does not support! It is supported on ARMv8-A however.
 FORCE_INLINE __m128i _mm_cvtps_epi32(__m128 a)
 {
 #if defined(__ARM_FEATURE_FRINT)
-    return vreinterpretq_m128i_s32(vcvtq_s32_f32(vrnd32xq_f32(a)));
+    float32x4_t f = vreinterpretq_f32_m128(a);
+    int32x4_t cvt = vcvtq_s32_f32(vrnd32xq_f32(f));
+    return vreinterpretq_m128i_s32(_sse2neon_cvtps_epi32_fixup(f, cvt));
 #elif SSE2NEON_ARCH_AARCH64 || defined(__ARM_FEATURE_DIRECTED_ROUNDING)
+    float32x4_t f = vreinterpretq_f32_m128(a);
+    int32x4_t cvt;
     switch (_MM_GET_ROUNDING_MODE()) {
     case _MM_ROUND_NEAREST:
-        return vreinterpretq_m128i_s32(vcvtnq_s32_f32(a));
+        cvt = vcvtnq_s32_f32(f);
+        break;
     case _MM_ROUND_DOWN:
-        return vreinterpretq_m128i_s32(vcvtmq_s32_f32(a));
+        cvt = vcvtmq_s32_f32(f);
+        break;
     case _MM_ROUND_UP:
-        return vreinterpretq_m128i_s32(vcvtpq_s32_f32(a));
+        cvt = vcvtpq_s32_f32(f);
+        break;
     default:  // _MM_ROUND_TOWARD_ZERO
-        return vreinterpretq_m128i_s32(vcvtq_s32_f32(a));
+        cvt = vcvtq_s32_f32(f);
+        break;
     }
+    return vreinterpretq_m128i_s32(_sse2neon_cvtps_epi32_fixup(f, cvt));
 #else
     float *f = _sse2neon_reinterpret_cast(float *, &a);
     switch (_MM_GET_ROUNDING_MODE()) {
     case _MM_ROUND_NEAREST: {
+        float32x4_t fv = vreinterpretq_f32_m128(a);
         uint32x4_t signmask = vdupq_n_u32(0x80000000);
-        float32x4_t half = vbslq_f32(signmask, vreinterpretq_f32_m128(a),
-                                     vdupq_n_f32(0.5f)); /* +/- 0.5 */
-        int32x4_t r_normal = vcvtq_s32_f32(vaddq_f32(
-            vreinterpretq_f32_m128(a), half)); /* round to integer: [a + 0.5]*/
-        int32x4_t r_trunc = vcvtq_s32_f32(
-            vreinterpretq_f32_m128(a)); /* truncate to integer: [a] */
+        float32x4_t half =
+            vbslq_f32(signmask, fv, vdupq_n_f32(0.5f)); /* +/- 0.5 */
+        int32x4_t r_normal =
+            vcvtq_s32_f32(vaddq_f32(fv, half)); /* round to integer: [a + 0.5]*/
+        int32x4_t r_trunc = vcvtq_s32_f32(fv);  /* truncate to integer: [a] */
         int32x4_t plusone = vreinterpretq_s32_u32(vshrq_n_u32(
             vreinterpretq_u32_s32(vnegq_s32(r_trunc)), 31)); /* 1 or 0 */
         int32x4_t r_even = vbicq_s32(vaddq_s32(r_trunc, plusone),
                                      vdupq_n_s32(1)); /* ([a] + {0,1}) & ~1 */
         float32x4_t delta = vsubq_f32(
-            vreinterpretq_f32_m128(a),
-            vcvtq_f32_s32(r_trunc)); /* compute delta: delta = (a - [a]) */
+            fv, vcvtq_f32_s32(r_trunc)); /* compute delta: delta = (a - [a]) */
         uint32x4_t is_delta_half =
             vceqq_f32(delta, half); /* delta == +/- 0.5 */
-        return vreinterpretq_m128i_s32(
-            vbslq_s32(is_delta_half, r_even, r_normal));
+        int32x4_t result = vbslq_s32(is_delta_half, r_even, r_normal);
+        return vreinterpretq_m128i_s32(_sse2neon_cvtps_epi32_fixup(fv, result));
     }
     case _MM_ROUND_DOWN:
-        return _mm_set_epi32(floorf(f[3]), floorf(f[2]), floorf(f[1]),
-                             floorf(f[0]));
+        return _mm_set_epi32(
+            _sse2neon_cvtf_s32(floorf(f[3])), _sse2neon_cvtf_s32(floorf(f[2])),
+            _sse2neon_cvtf_s32(floorf(f[1])), _sse2neon_cvtf_s32(floorf(f[0])));
     case _MM_ROUND_UP:
-        return _mm_set_epi32(ceilf(f[3]), ceilf(f[2]), ceilf(f[1]),
-                             ceilf(f[0]));
+        return _mm_set_epi32(
+            _sse2neon_cvtf_s32(ceilf(f[3])), _sse2neon_cvtf_s32(ceilf(f[2])),
+            _sse2neon_cvtf_s32(ceilf(f[1])), _sse2neon_cvtf_s32(ceilf(f[0])));
     default:  // _MM_ROUND_TOWARD_ZERO
-        return _mm_set_epi32(_sse2neon_static_cast(int32_t, f[3]),
-                             _sse2neon_static_cast(int32_t, f[2]),
-                             _sse2neon_static_cast(int32_t, f[1]),
-                             _sse2neon_static_cast(int32_t, f[0]));
+        return _mm_set_epi32(_sse2neon_cvtf_s32(f[3]), _sse2neon_cvtf_s32(f[2]),
+                             _sse2neon_cvtf_s32(f[1]),
+                             _sse2neon_cvtf_s32(f[0]));
     }
 #endif
 }
@@ -4617,10 +4651,13 @@ FORCE_INLINE __m64 _mm_cvttpd_pi32(__m128d a)
 
 // Convert packed single-precision (32-bit) floating-point elements in a to
 // packed 32-bit integers with truncation, and store the results in dst.
+// x86 returns INT32_MIN ("integer indefinite") for NaN and out-of-range values.
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cvttps_epi32
 FORCE_INLINE __m128i _mm_cvttps_epi32(__m128 a)
 {
-    return vreinterpretq_m128i_s32(vcvtq_s32_f32(vreinterpretq_f32_m128(a)));
+    float32x4_t f = vreinterpretq_f32_m128(a);
+    int32x4_t cvt = vcvtq_s32_f32(f);
+    return vreinterpretq_m128i_s32(_sse2neon_cvtps_epi32_fixup(f, cvt));
 }
 
 // Convert the lower double-precision (64-bit) floating-point element in a to a

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -5144,7 +5144,7 @@ result_t test_mm_cvttps_epi32(const SSE2NEONTestImpl &impl, uint32_t iter)
     __m128 a = load_m128(_a);
     int32_t trun[4];
     for (uint32_t i = 0; i < 4; i++) {
-        trun[i] = static_cast<int32_t>(_a[i]);
+        trun[i] = sse2neon_saturate_cast_int32(_a[i]);
     }
 
     __m128i ret = _mm_cvttps_epi32(a);


### PR DESCRIPTION
ARM NEON vcvtq_s32_f32 returns 0 for NaN and INT32_MAX for positive overflow, while x86 SSE returns INT32_MIN ("integer indefinite") for both cases. Add vectorized fixup helper and apply to all affected intrinsics: `_mm_cvttps_epi32`, `_mm_cvtps_epi32`, `_mm_cvtt_ps2pi`, `_mm_cvtt_ss2si`, and `_mm_cvttss_si64`.

This also fixes `test_mm_cvttps_epi32` which used undefined behavior (`static_cast<int32_t>` on out-of-range float) and add comprehensive IEEE-754 saturation tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align NEON float-to-int conversions with x86 SSE: NaN and out-of-range values now return INT32_MIN (INT64_MIN for 64-bit). Adds a vectorized fixup and applies it across affected intrinsics; expands IEEE-754 tests and removes UB in cvttps tests.

- **Bug Fixes**
  - Added _sse2neon_cvtps_epi32_fixup to map NaN and >= 2^31.0f to INT32_MIN.
  - Updated intrinsics: _mm_cvttps_epi32, _mm_cvtps_epi32, _mm_cvtt_ps2pi, _mm_cvtt_ss2si, _mm_cvttss_si64; scalar paths use _sse2neon_cvtf_s32/_s64.
  - Tests: added saturation coverage and fixed test_mm_cvttps_epi32 to use sse2neon_saturate_cast_int32.

<sup>Written for commit 1fd7af24a278da14f8d8b30cdbd648aebfc8a41a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

