### PR TITLE
Add denormal flush-to-zero mode tests

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -8,11 +8,24 @@
 #include "sse2neon.h"
 #elif defined(__x86_64__) || defined(__i386__)
 #include <emmintrin.h>
+#include <pmmintrin.h>
 #include <smmintrin.h>
 #include <tmmintrin.h>
 #include <wmmintrin.h>
 #include <x86intrin.h>
 #include <xmmintrin.h>
+
+// Fallback definitions for FTZ/DAZ macros if not provided by system headers
+#ifndef _MM_FLUSH_ZERO_MASK
+#define _MM_FLUSH_ZERO_MASK 0x8000
+#define _MM_FLUSH_ZERO_ON 0x8000
+#define _MM_FLUSH_ZERO_OFF 0x0000
+#endif
+#ifndef _MM_DENORMALS_ZERO_MASK
+#define _MM_DENORMALS_ZERO_MASK 0x0040
+#define _MM_DENORMALS_ZERO_ON 0x0040
+#define _MM_DENORMALS_ZERO_OFF 0x0000
+#endif
 
 // __int64 is defined in the Intrinsics Guide which maps to different datatype
 // in different data model


### PR DESCRIPTION
- Document ARM platform limitations for FTZ/DAZ in _mm_setcsr/_mm_getcsr
- Add FTZ/DAZ macro comments explaining unified FPCR bit 24 behavior
- Enhance test_mm_getcsr/test_mm_setcsr to validate FTZ/DAZ bits
- Add 4 IEEE-754 tests: ftz_output_flush, daz_input_flush, ftz_daz_disabled, ftz_getcsr_roundtrip









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add FTZ/DAZ mode tests and document ARM’s unified FPCR/FPSCR bit 24 to ensure consistent denormal handling across x86 and ARM. Tightens _mm_setcsr/_mm_getcsr semantics and adds IEEE-754 coverage to prevent regressions.

- **New Features**
  - Document FTZ/DAZ macros and ARM platform limits in sse2neon.h (unified bit 24; ARMv7 always-flush; ARMv8 FPCR.FZ controls denormals).
  - Enhance test_mm_getcsr/test_mm_setcsr to validate FTZ/DAZ bits, clear both masks together, and verify round-trip behavior.
  - Add 4 IEEE-754 tests: ftz_output_flush, daz_input_flush, ftz_daz_disabled (with AArch32 special-case), ftz_getcsr_roundtrip.

<sup>Written for commit cf16be02b8c49ed507a719032133b8a6b603eb70. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









