### PR TITLE
Refine Makefile convenience targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,27 @@ indent:
 	fi
 	$(CLANG_FORMAT) -i sse2neon.h tests/*.cpp tests/*.h
 
+# Convenience target for running only main tests (skip IEEE-754)
+check-main: $(EXEC)
+ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
+	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+endif
+	$(EXEC_WRAPPER) $(EXEC)
+
+# Convenience target for running only IEEE-754 edge case tests (skip main)
+check-ieee754: $(IEEE754_EXEC)
+ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
+	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+endif
+	$(EXEC_WRAPPER) $(IEEE754_EXEC)
+
 # Convenience target for running tests with UBSan
 check-ubsan: clean
 	$(MAKE) SANITIZE=undefined check
+
+# Convenience target for running tests with ASan
+check-asan: clean
+	$(MAKE) SANITIZE=address check
 
 # Convenience target for running tests with strict aliasing checks
 check-strict-aliasing: clean
@@ -146,7 +164,7 @@ check-strict-aliasing: clean
 check-macros:
 	@python3 .ci/check-macros.py sse2neon.h
 
-.PHONY: clean check check-ubsan check-strict-aliasing check-macros indent ieee754
+.PHONY: clean check check-main check-ieee754 check-ubsan check-asan check-strict-aliasing check-macros indent ieee754
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps) sse2neon.h.gch
 	$(RM) $(IEEE754_OBJS) $(IEEE754_EXEC) $(ieee754_deps)

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -8588,14 +8588,15 @@ static uint16_t _sse2neon_aggregate_equal_any_8x16(int la,
     ((vmaxvq_u8(vandq_u8(vec, vreinterpretq_u8_m128i(mtx[i]))) ? 1U : 0U) \
      << (i))
     uint16_t res = _sse2neon_static_cast(
-        uint16_t, SSE2NEON_UMAXV_MATCH(0) | SSE2NEON_UMAXV_MATCH(1) |
-                      SSE2NEON_UMAXV_MATCH(2) | SSE2NEON_UMAXV_MATCH(3) |
-                      SSE2NEON_UMAXV_MATCH(4) | SSE2NEON_UMAXV_MATCH(5) |
-                      SSE2NEON_UMAXV_MATCH(6) | SSE2NEON_UMAXV_MATCH(7) |
-                      SSE2NEON_UMAXV_MATCH(8) | SSE2NEON_UMAXV_MATCH(9) |
-                      SSE2NEON_UMAXV_MATCH(10) | SSE2NEON_UMAXV_MATCH(11) |
-                      SSE2NEON_UMAXV_MATCH(12) | SSE2NEON_UMAXV_MATCH(13) |
-                      SSE2NEON_UMAXV_MATCH(14) | SSE2NEON_UMAXV_MATCH(15));
+        uint16_t, (SSE2NEON_UMAXV_MATCH(0) | SSE2NEON_UMAXV_MATCH(1) |
+                   SSE2NEON_UMAXV_MATCH(2) | SSE2NEON_UMAXV_MATCH(3) |
+                   SSE2NEON_UMAXV_MATCH(4) | SSE2NEON_UMAXV_MATCH(5) |
+                   SSE2NEON_UMAXV_MATCH(6) | SSE2NEON_UMAXV_MATCH(7) |
+                   SSE2NEON_UMAXV_MATCH(8) | SSE2NEON_UMAXV_MATCH(9) |
+                   SSE2NEON_UMAXV_MATCH(10) | SSE2NEON_UMAXV_MATCH(11) |
+                   SSE2NEON_UMAXV_MATCH(12) | SSE2NEON_UMAXV_MATCH(13) |
+                   SSE2NEON_UMAXV_MATCH(14) | SSE2NEON_UMAXV_MATCH(15)) &
+                      0xFFFFu);
 #undef SSE2NEON_UMAXV_MATCH
 #else
     /* ARMv7: Use OR-based horizontal reduction (faster than vpmax cascade).
@@ -8628,10 +8629,11 @@ static uint16_t _sse2neon_aggregate_equal_any_16x8(int la,
     ((vmaxvq_u16(vandq_u16(vec, vreinterpretq_u16_m128i(mtx[i]))) ? 1U : 0U) \
      << (i))
     uint16_t res = _sse2neon_static_cast(
-        uint16_t, SSE2NEON_UMAXV_MATCH16(0) | SSE2NEON_UMAXV_MATCH16(1) |
-                      SSE2NEON_UMAXV_MATCH16(2) | SSE2NEON_UMAXV_MATCH16(3) |
-                      SSE2NEON_UMAXV_MATCH16(4) | SSE2NEON_UMAXV_MATCH16(5) |
-                      SSE2NEON_UMAXV_MATCH16(6) | SSE2NEON_UMAXV_MATCH16(7));
+        uint16_t, (SSE2NEON_UMAXV_MATCH16(0) | SSE2NEON_UMAXV_MATCH16(1) |
+                   SSE2NEON_UMAXV_MATCH16(2) | SSE2NEON_UMAXV_MATCH16(3) |
+                   SSE2NEON_UMAXV_MATCH16(4) | SSE2NEON_UMAXV_MATCH16(5) |
+                   SSE2NEON_UMAXV_MATCH16(6) | SSE2NEON_UMAXV_MATCH16(7)) &
+                      0xFFu);
 #undef SSE2NEON_UMAXV_MATCH16
 #else
     /* ARMv7: Use OR-based horizontal reduction */

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,5 +1,11 @@
 #ifndef SSE2NEONCOMMON_H
 #define SSE2NEONCOMMON_H
+
+/* ANSI color codes for test output */
+#define COLOR_GREEN "\033[32m"
+#define COLOR_RED "\033[31m"
+#define COLOR_RESET "\033[0m"
+
 #include <climits>
 #include <cmath>
 #include <cstdint>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -14,13 +14,15 @@ int main(int /*argc*/, const char ** /*argv*/)
         // If the test fails, we will run it again so we can step into the
         // debugger and figure out why!
         if (ret == SSE2NEON::TEST_FAIL) {
-            printf("Test %-30s failed\n", SSE2NEON::instructionString[it]);
+            printf("Test %-35s [" COLOR_RED "FAIL" COLOR_RESET "]\n",
+                   SSE2NEON::instructionString[it]);
             failedCount++;
         } else if (ret == SSE2NEON::TEST_UNIMPL) {
-            printf("Test %-30s skipped\n", SSE2NEON::instructionString[it]);
+            printf("Test %-35s [SKIP]\n", SSE2NEON::instructionString[it]);
             ignoreCount++;
         } else {
-            printf("Test %-30s passed\n", SSE2NEON::instructionString[it]);
+            printf("Test %-35s [ " COLOR_GREEN "OK" COLOR_RESET " ]\n",
+                   SSE2NEON::instructionString[it]);
             passCount++;
         }
     }


### PR DESCRIPTION
This adds check-{main,ieee754,asan} targets and unifies test output format.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds make targets to run specific test suites and standardizes test output with clear, colorized OK/FAIL/SKIP statuses.

- **New Features**
  - Makefile: check-main (main tests), check-ieee754 (IEEE-754 tests), and check-asan (AddressSanitizer). Existing check-ubsan and others remain.
  - Tests: unified, colorized output via shared ANSI codes in tests/common.h.

- **Bug Fixes**
  - sse2neon.h: mask aggregate result bits (0xFFFF/0xFF) and tighten casting.
  - Tests: use explicit unsigned casts when updating MXCSR (_mm_setcsr) to avoid UB.

<sup>Written for commit f166bac6d566d5bd01d353f54ac4e4d9c63a9f09. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



