### PR TITLE
Add iOS compatibility wrapper for vcreate_u64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,3 +241,32 @@ jobs:
             --gcc-toolchain=/usr \
             -isystem /usr/aarch64-linux-gnu/include \
             -march=armv8-a+simd+crypto+crc
+
+  # iOS build verification
+  host-ios:
+    runs-on: macos-14
+    strategy:
+      matrix:
+        include:
+          - sdk: iphoneos
+            target: arm64-apple-ios14.0
+          - sdk: iphonesimulator
+            target: arm64-apple-ios15.0-simulator
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: build for iOS
+        run: |
+          echo '#include "sse2neon.h"' | xcrun --sdk ${{ matrix.sdk }} clang++ \
+            --target=${{ matrix.target }} \
+            -isysroot $(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path) \
+            -std=c++14 -Wall -Wextra -Werror -Wno-unused-parameter \
+            -I. -x c++ -fsyntax-only -
+      - name: build for iOS (CRC32 enabled)
+        run: |
+          echo '#include "sse2neon.h"' | xcrun --sdk ${{ matrix.sdk }} clang++ \
+            --target=${{ matrix.target }} \
+            -isysroot $(xcrun --sdk ${{ matrix.sdk }} --show-sdk-path) \
+            -march=armv8-a+crc \
+            -std=c++14 -Wall -Wextra -Werror -Wno-unused-parameter \
+            -I. -x c++ -fsyntax-only -


### PR DESCRIPTION
On iOS, vcreate_u64 may be defined as a macro in <arm_neon.h>, which can cause parsing issues in complex macro expansions. This adds wrapper using vdup_n_u64() that provides a function-call interface.











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS builds by wrapping vcreate_u64 to avoid arm_neon.h macro conflicts and using it in CRC32C code paths. Adds iOS build checks in CI to prevent regressions.

- **Bug Fixes**
  - Added _sse2neon_vcreate_u64 wrapper (uses vdup_n_u64) and enabled it by default on AArch64 iOS; can be toggled with SSE2NEON_IOS_COMPAT.
  - Replaced vcreate_u64 calls in CRC32C macros with the wrapper for stable parsing.
  - Added GitHub Actions jobs to compile on iphoneos and iphonesimulator targets.

<sup>Written for commit f155e459ea8e2d1be3f7a288477f24399879d8d0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











