### PR TITLE
Add differential testing for x86/ARM semantic verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,3 +270,48 @@ jobs:
             -march=armv8-a+crc \
             -std=c++14 -Wall -Wextra -Werror -Wno-unused-parameter \
             -I. -x c++ -fsyntax-only -
+
+  # Differential Testing: Generate golden reference data on x86
+  # This captures native SSE outputs for comparison against sse2neon on ARM
+  differential-x86:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: build differential test harness (native SSE)
+        run: make tests/differential
+      - name: generate golden reference data
+        run: |
+          mkdir -p golden
+          ./tests/differential --generate golden
+          echo "Generated $(ls golden/*.golden | wc -l) golden files"
+      - name: upload golden data artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: differential-golden-data
+          path: golden/
+          retention-days: 1
+
+  # Differential Testing: Verify sse2neon against x86 golden data on ARM
+  differential-arm:
+    runs-on: ubuntu-24.04-arm
+    needs: differential-x86
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: download golden data from x86
+        uses: actions/download-artifact@v6
+        with:
+          name: differential-golden-data
+          path: golden/
+      - name: show golden data info
+        run: |
+          echo "Golden files from x86:"
+          ls -la golden/ | head -20
+          echo "Total: $(ls golden/*.golden | wc -l) files"
+      - name: build differential test harness (sse2neon)
+        run: make FEATURE=crypto+crc tests/differential
+      - name: verify sse2neon against x86 golden data
+        run: |
+          echo "Comparing sse2neon (ARM) against native SSE (x86)..."
+          ./tests/differential --verify golden/

--- a/scripts/gen-golden.py
+++ b/scripts/gen-golden.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Golden Reference Data Generator for sse2neon Differential Testing
+
+This script builds and runs the differential test harness on x86 to generate
+golden reference data that can be used to verify NEON implementations on ARM.
+
+Usage:
+    python3 scripts/gen-golden.py [output_dir]
+
+Requirements:
+    - Must run on x86/x86_64 platform
+    - GCC or Clang compiler with SSE support
+    - Output directory defaults to 'golden/'
+
+The generated golden data files contain the expected outputs from native x86
+SSE intrinsics. These are compared against sse2neon outputs on ARM platforms.
+
+Known x86/ARM differences are documented in IMPROVE.md and handled with
+appropriate tolerances in the verification phase.
+"""
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def check_platform():
+    """Verify we're running on x86."""
+    machine = platform.machine().lower()
+    if machine not in ("x86_64", "amd64", "i386", "i686", "x86"):
+        print(f"ERROR: This script must run on x86. Detected: {machine}")
+        print("Golden data generation requires native SSE execution.")
+        sys.exit(1)
+    return machine
+
+
+def find_compiler():
+    """Find a suitable C++ compiler."""
+    for compiler in ["g++", "clang++"]:
+        if shutil.which(compiler):
+            return compiler
+    print("ERROR: No C++ compiler found (tried g++, clang++)")
+    sys.exit(1)
+
+
+def build_differential(project_root, compiler):
+    """Build the differential test harness for x86."""
+    build_dir = os.path.join(project_root, "build_differential")
+    os.makedirs(build_dir, exist_ok=True)
+
+    # Source files
+    sources = ["tests/differential.cpp", "tests/common.cpp", "tests/binding.cpp"]
+
+    # Compiler flags for x86 SSE support
+    cflags = [
+        "-O2",
+        "-Wall",
+        "-std=gnu++14",
+        "-maes",
+        "-mpclmul",
+        "-mssse3",
+        "-msse4.2",
+        "-I.",
+    ]
+
+    output = os.path.join(build_dir, "differential")
+
+    cmd = [compiler] + cflags + sources + ["-o", output, "-lm"]
+
+    print(f"Building differential test harness...")
+    print(f"  Compiler: {compiler}")
+    print(f"  Command: {' '.join(cmd)}")
+
+    try:
+        subprocess.run(cmd, check=True, cwd=project_root)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Build failed with exit code {e.returncode}")
+        sys.exit(1)
+
+    return output
+
+
+def generate_golden(executable, output_dir):
+    """Run the differential harness to generate golden data."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    cmd = [executable, "--generate", output_dir]
+
+    print(f"\nGenerating golden reference data...")
+    print(f"  Output directory: {output_dir}")
+
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=False)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Golden generation failed with exit code {e.returncode}")
+        sys.exit(1)
+
+    # Count generated files
+    golden_files = [f for f in os.listdir(output_dir) if f.endswith(".golden")]
+    print(f"\nGenerated {len(golden_files)} golden data files")
+
+    return len(golden_files)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate golden reference data for sse2neon differential testing"
+    )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default="golden",
+        help="Output directory for golden data (default: golden/)",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clean existing golden data before generating",
+    )
+    args = parser.parse_args()
+
+    # Find project root (parent of scripts/)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(script_dir)
+
+    print("sse2neon Golden Data Generator")
+    print("=" * 40)
+
+    # Platform check
+    machine = check_platform()
+    print(f"Platform: {machine} (OK)")
+
+    # Find compiler
+    compiler = find_compiler()
+    print(f"Compiler: {compiler}")
+
+    # Output directory
+    output_dir = os.path.join(project_root, args.output_dir)
+    if args.clean and os.path.exists(output_dir):
+        print(f"\nCleaning existing golden data in {output_dir}...")
+        shutil.rmtree(output_dir)
+
+    # Build
+    executable = build_differential(project_root, compiler)
+    print(f"Built: {executable}")
+
+    # Generate
+    count = generate_golden(executable, output_dir)
+
+    print("\n" + "=" * 40)
+    print("Golden data generation complete!")
+    print(f"\nTo verify on ARM:")
+    print(f"  1. Copy '{args.output_dir}/' to ARM target")
+    print(f"  2. Run: make check-differential GOLDEN_DIR={args.output_dir}")
+    print("\nSee IMPROVE.md for known x86/ARM semantic differences.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/differential.cpp
+++ b/tests/differential.cpp
@@ -1,0 +1,917 @@
+/*
+ * Differential Testing Harness for sse2neon
+ *
+ * Purpose: Verify NEON implementations match x86 SSE semantics by comparing
+ * outputs against golden reference data generated on x86.
+ *
+ * Usage:
+ *   1. On x86: ./tests/differential --generate golden/
+ *   2. On ARM: ./tests/differential --verify golden/
+ *
+ * The harness uses deterministic PRNG (seed=123456) to ensure identical
+ * inputs on both platforms.
+ */
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "binding.h"
+#include "common.h"
+#include "impl.h"
+
+namespace SSE2NEON
+{
+
+/* Define instructionString array - must match INTRIN_LIST in impl.h */
+const char *instructionString[] = {
+#define _(x) #x,
+    INTRIN_LIST
+#undef _
+};
+
+/* Golden data file format:
+ * - Header: magic (4), version (4), intrinsic_id (4), iteration_count (4)
+ * - Per iteration: output_data (16 bytes for __m128)
+ */
+constexpr uint32_t GOLDEN_MAGIC = 0x474F4C44;  // "GOLD"
+constexpr uint32_t GOLDEN_VERSION = 1;
+
+/* Reduced iterations for differential testing (100 vs 10000 for main tests) */
+constexpr uint32_t DIFFERENTIAL_ITERATIONS = 100;
+
+struct GoldenHeader {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t intrinsic_id;
+    uint32_t iteration_count;
+};
+
+/* SplitMix64 PRNG - must match impl.cpp exactly */
+static uint64_t prng_state;
+static const double TWOPOWER64 = 18446744073709551616.0;
+
+static void init_prng(uint64_t seed)
+{
+    prng_state = seed;
+}
+
+static double prng_next()
+{
+    uint64_t z = (prng_state += 0x9e3779b97f4a7c15);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+    return static_cast<double>(z ^ (z >> 31));
+}
+
+static float ranf()
+{
+    return static_cast<float>(prng_next() / TWOPOWER64);
+}
+
+static float ranf(float low, float high)
+{
+    return ranf() * (high - low) + low;
+}
+
+/* Test data structure matching impl.cpp */
+class DifferentialTestData
+{
+public:
+    float *mTestFloatPointer1;
+    float *mTestFloatPointer2;
+    int32_t *mTestIntPointer1;
+    int32_t *mTestIntPointer2;
+    float mTestFloats[10000];
+    int32_t mTestInts[10000];
+
+    DifferentialTestData()
+    {
+        mTestFloatPointer1 =
+            static_cast<float *>(platformAlignedAlloc(sizeof(__m128)));
+        mTestFloatPointer2 =
+            static_cast<float *>(platformAlignedAlloc(sizeof(__m128)));
+        mTestIntPointer1 =
+            static_cast<int32_t *>(platformAlignedAlloc(sizeof(__m128i)));
+        mTestIntPointer2 =
+            static_cast<int32_t *>(platformAlignedAlloc(sizeof(__m128i)));
+
+        /* Initialize with same PRNG seed as main tests */
+        init_prng(123456);
+        for (uint32_t i = 0; i < 10000; i++) {
+            mTestFloats[i] = ranf(-100000, 100000);
+            mTestInts[i] = static_cast<int32_t>(ranf(-100000, 100000));
+        }
+    }
+
+    ~DifferentialTestData()
+    {
+        platformAlignedFree(mTestFloatPointer1);
+        platformAlignedFree(mTestFloatPointer2);
+        platformAlignedFree(mTestIntPointer1);
+        platformAlignedFree(mTestIntPointer2);
+    }
+
+    void loadIteration(uint32_t i)
+    {
+        mTestFloatPointer1[0] = mTestFloats[i];
+        mTestFloatPointer1[1] = mTestFloats[i + 1];
+        mTestFloatPointer1[2] = mTestFloats[i + 2];
+        mTestFloatPointer1[3] = mTestFloats[i + 3];
+
+        mTestFloatPointer2[0] = mTestFloats[i + 4];
+        mTestFloatPointer2[1] = mTestFloats[i + 5];
+        mTestFloatPointer2[2] = mTestFloats[i + 6];
+        mTestFloatPointer2[3] = mTestFloats[i + 7];
+
+        mTestIntPointer1[0] = mTestInts[i];
+        mTestIntPointer1[1] = mTestInts[i + 1];
+        mTestIntPointer1[2] = mTestInts[i + 2];
+        mTestIntPointer1[3] = mTestInts[i + 3];
+
+        mTestIntPointer2[0] = mTestInts[i + 4];
+        mTestIntPointer2[1] = mTestInts[i + 5];
+        mTestIntPointer2[2] = mTestInts[i + 6];
+        mTestIntPointer2[3] = mTestInts[i + 7];
+    }
+};
+
+/* Output union for capturing intrinsic results */
+union OutputData {
+    __m128 ps;
+    __m128i si;
+    __m128d pd;
+    __m64 m64;
+    uint8_t bytes[16];
+    uint32_t u32[4];
+    uint64_t u64[2];
+    int32_t i32[4];
+    int64_t i64[2];
+    float f32[4];
+    double f64[2];
+};
+
+/* Known differences between x86 and ARM
+ *
+ * These intrinsics have documented semantic differences that require
+ * special comparison logic or tolerance.
+ */
+enum DiffCategory {
+    DIFF_NONE = 0,        /* Exact match required */
+    DIFF_FLOAT_TOLERANCE, /* FP tolerance allowed (rsqrt, rcp approximations) */
+    DIFF_NAN_HANDLING,    /* NaN propagation differs without PRECISE_MINMAX */
+    DIFF_DENORMAL,        /* Denormal handling may differ (FTZ/DAZ) */
+    DIFF_SKIP,            /* Skip comparison (memory ops, side effects) */
+};
+
+struct IntrinsicInfo {
+    InstructionTest id;
+    const char *name;
+    DiffCategory category;
+    float tolerance; /* For DIFF_FLOAT_TOLERANCE */
+};
+
+/* Intrinsics with known x86/ARM differences
+ *
+ * Reference: IMPROVE.md Migration Guide section
+ */
+// clang-format off
+static const IntrinsicInfo known_differences[] = {
+    /* Approximation intrinsics - relaxed precision */
+    {it_mm_rcp_ps, "mm_rcp_ps", DIFF_FLOAT_TOLERANCE, 1.5e-4f},
+    {it_mm_rcp_ss, "mm_rcp_ss", DIFF_FLOAT_TOLERANCE, 1.5e-4f},
+    {it_mm_rsqrt_ps, "mm_rsqrt_ps", DIFF_FLOAT_TOLERANCE, 1.5e-4f},
+    {it_mm_rsqrt_ss, "mm_rsqrt_ss", DIFF_FLOAT_TOLERANCE, 1.5e-4f},
+
+    /* Min/max with NaN - requires SSE2NEON_PRECISE_MINMAX for exact match */
+#if !SSE2NEON_PRECISE_MINMAX
+    {it_mm_min_ps, "mm_min_ps", DIFF_NAN_HANDLING, 0},
+    {it_mm_min_ss, "mm_min_ss", DIFF_NAN_HANDLING, 0},
+    {it_mm_max_ps, "mm_max_ps", DIFF_NAN_HANDLING, 0},
+    {it_mm_max_ss, "mm_max_ss", DIFF_NAN_HANDLING, 0},
+    {it_mm_min_pd, "mm_min_pd", DIFF_NAN_HANDLING, 0},
+    {it_mm_min_sd, "mm_min_sd", DIFF_NAN_HANDLING, 0},
+    {it_mm_max_pd, "mm_max_pd", DIFF_NAN_HANDLING, 0},
+    {it_mm_max_sd, "mm_max_sd", DIFF_NAN_HANDLING, 0},
+#endif
+
+    /* Memory/side-effect intrinsics - skip comparison */
+    {it_mm_malloc, "mm_malloc", DIFF_SKIP, 0},
+    {it_mm_free, "mm_free", DIFF_SKIP, 0},
+    {it_mm_empty, "mm_empty", DIFF_SKIP, 0},
+    {it_mm_sfence, "mm_sfence", DIFF_SKIP, 0},
+    {it_mm_lfence, "mm_lfence", DIFF_SKIP, 0},
+    {it_mm_mfence, "mm_mfence", DIFF_SKIP, 0},
+    {it_mm_pause, "mm_pause", DIFF_SKIP, 0},
+    {it_mm_clflush, "mm_clflush", DIFF_SKIP, 0},
+    {it_mm_prefetch, "mm_prefetch", DIFF_SKIP, 0},
+    {it_mm_getcsr, "mm_getcsr", DIFF_SKIP, 0},
+    {it_mm_setcsr, "mm_setcsr", DIFF_SKIP, 0},
+    {it_mm_stream_pi, "mm_stream_pi", DIFF_SKIP, 0},
+    {it_mm_stream_ps, "mm_stream_ps", DIFF_SKIP, 0},
+    {it_mm_stream_pd, "mm_stream_pd", DIFF_SKIP, 0},
+    {it_mm_stream_si32, "mm_stream_si32", DIFF_SKIP, 0},
+    {it_mm_stream_si64, "mm_stream_si64", DIFF_SKIP, 0},
+    {it_mm_stream_si128, "mm_stream_si128", DIFF_SKIP, 0},
+    {it_mm_maskmove_si64, "mm_maskmove_si64", DIFF_SKIP, 0},
+    {it_m_maskmovq, "m_maskmovq", DIFF_SKIP, 0},
+    {it_mm_maskmoveu_si128, "mm_maskmoveu_si128", DIFF_SKIP, 0},
+    {it_rdtsc, "rdtsc", DIFF_SKIP, 0},
+
+    /* Flush-to-zero mode intrinsics */
+    {it_mm_get_flush_zero_mode, "mm_get_flush_zero_mode", DIFF_SKIP, 0},
+    {it_mm_set_flush_zero_mode, "mm_set_flush_zero_mode", DIFF_SKIP, 0},
+    {it_mm_get_denormals_zero_mode, "mm_get_denormals_zero_mode", DIFF_SKIP, 0},
+    {it_mm_set_denormals_zero_mode, "mm_set_denormals_zero_mode", DIFF_SKIP, 0},
+    {it_mm_get_rounding_mode, "mm_get_rounding_mode", DIFF_SKIP, 0},
+    {it_mm_set_rounding_mode, "mm_set_rounding_mode", DIFF_SKIP, 0},
+
+    /* Sentinel */
+    {it_last, nullptr, DIFF_NONE, 0},
+};
+// clang-format on
+
+static DiffCategory get_diff_category(InstructionTest id, float *tolerance)
+{
+    for (size_t i = 0; known_differences[i].name != nullptr; i++) {
+        if (known_differences[i].id == id) {
+            if (tolerance)
+                *tolerance = known_differences[i].tolerance;
+            return known_differences[i].category;
+        }
+    }
+    if (tolerance)
+        *tolerance = 0;
+    return DIFF_NONE;
+}
+
+/* Helper to create directory if it doesn't exist */
+static bool ensure_directory(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) == 0)
+        return S_ISDIR(st.st_mode);
+    return mkdir(path, 0755) == 0;
+}
+
+/* Compare two outputs with optional tolerance */
+static bool compare_output(const OutputData &golden,
+                           const OutputData &actual,
+                           DiffCategory cat,
+                           float tolerance)
+{
+    switch (cat) {
+    case DIFF_SKIP:
+        return true;
+
+    case DIFF_NAN_HANDLING:
+        /* For NaN handling differences, check if both are NaN or both match */
+        for (int i = 0; i < 4; i++) {
+            bool g_nan = std::isnan(golden.f32[i]);
+            bool a_nan = std::isnan(actual.f32[i]);
+            if (g_nan || a_nan) {
+                /* Allow both NaN or golden NaN with any actual value */
+                continue;
+            }
+            if (golden.u32[i] != actual.u32[i])
+                return false;
+        }
+        return true;
+
+    case DIFF_FLOAT_TOLERANCE:
+        for (int i = 0; i < 4; i++) {
+            if (std::isnan(golden.f32[i]) && std::isnan(actual.f32[i]))
+                continue;
+            if (std::isinf(golden.f32[i]) && std::isinf(actual.f32[i])) {
+                if ((golden.f32[i] > 0) != (actual.f32[i] > 0))
+                    return false;
+                continue;
+            }
+            float diff = std::fabs(golden.f32[i] - actual.f32[i]);
+            float rel = std::fabs(golden.f32[i]) > 1e-6f
+                            ? diff / std::fabs(golden.f32[i])
+                            : diff;
+            if (rel > tolerance && diff > tolerance)
+                return false;
+        }
+        return true;
+
+    case DIFF_DENORMAL:
+    case DIFF_NONE:
+    default:
+        /* Exact bit match required */
+        return memcmp(golden.bytes, actual.bytes, 16) == 0;
+    }
+}
+
+/* Execute a single intrinsic and capture output
+ *
+ * This is a simplified version - full implementation would need to handle
+ * each intrinsic's specific signature and output type.
+ */
+static bool execute_intrinsic(InstructionTest id,
+                              DifferentialTestData &data,
+                              OutputData &out)
+{
+    memset(&out, 0, sizeof(out));
+
+    const float *fp1 = data.mTestFloatPointer1;
+    const float *fp2 = data.mTestFloatPointer2;
+    const int32_t *ip1 = data.mTestIntPointer1;
+    const int32_t *ip2 = data.mTestIntPointer2;
+
+    /* Load standard inputs */
+    __m128 a_ps = _mm_loadu_ps(fp1);
+    __m128 b_ps = _mm_loadu_ps(fp2);
+    __m128i a_si = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ip1));
+    __m128i b_si = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ip2));
+    __m128d a_pd =
+        _mm_loadu_pd(reinterpret_cast<const double *>(data.mTestFloatPointer1));
+    __m128d b_pd =
+        _mm_loadu_pd(reinterpret_cast<const double *>(data.mTestFloatPointer2));
+
+    (void) a_pd;
+    (void) b_pd;
+    (void) a_si;
+    (void) b_si;
+
+    /* Representative intrinsics for differential testing
+     *
+     * This covers the major categories; full coverage would enumerate all 544.
+     * Priority: intrinsics with known semantic complexity or past issues.
+     */
+    switch (id) {
+    /* Arithmetic - float */
+    case it_mm_add_ps:
+        out.ps = _mm_add_ps(a_ps, b_ps);
+        return true;
+    case it_mm_sub_ps:
+        out.ps = _mm_sub_ps(a_ps, b_ps);
+        return true;
+    case it_mm_mul_ps:
+        out.ps = _mm_mul_ps(a_ps, b_ps);
+        return true;
+    case it_mm_div_ps:
+        out.ps = _mm_div_ps(a_ps, b_ps);
+        return true;
+    case it_mm_add_ss:
+        out.ps = _mm_add_ss(a_ps, b_ps);
+        return true;
+    case it_mm_sub_ss:
+        out.ps = _mm_sub_ss(a_ps, b_ps);
+        return true;
+    case it_mm_mul_ss:
+        out.ps = _mm_mul_ss(a_ps, b_ps);
+        return true;
+    case it_mm_div_ss:
+        out.ps = _mm_div_ss(a_ps, b_ps);
+        return true;
+
+    /* Min/Max - critical for NaN handling */
+    case it_mm_min_ps:
+        out.ps = _mm_min_ps(a_ps, b_ps);
+        return true;
+    case it_mm_max_ps:
+        out.ps = _mm_max_ps(a_ps, b_ps);
+        return true;
+    case it_mm_min_ss:
+        out.ps = _mm_min_ss(a_ps, b_ps);
+        return true;
+    case it_mm_max_ss:
+        out.ps = _mm_max_ss(a_ps, b_ps);
+        return true;
+
+    /* Approximations - tolerance required */
+    case it_mm_rcp_ps:
+        out.ps = _mm_rcp_ps(a_ps);
+        return true;
+    case it_mm_rcp_ss:
+        out.ps = _mm_rcp_ss(a_ps);
+        return true;
+    case it_mm_rsqrt_ps:
+        /* Use absolute values to avoid NaN from negative sqrt */
+        out.ps = _mm_rsqrt_ps(_mm_andnot_ps(_mm_set1_ps(-0.0f), a_ps));
+        return true;
+    case it_mm_rsqrt_ss:
+        out.ps = _mm_rsqrt_ss(_mm_andnot_ps(_mm_set1_ps(-0.0f), a_ps));
+        return true;
+    case it_mm_sqrt_ps:
+        out.ps = _mm_sqrt_ps(_mm_andnot_ps(_mm_set1_ps(-0.0f), a_ps));
+        return true;
+    case it_mm_sqrt_ss:
+        out.ps = _mm_sqrt_ss(_mm_andnot_ps(_mm_set1_ps(-0.0f), a_ps));
+        return true;
+
+    /* Comparisons */
+    case it_mm_cmpeq_ps:
+        out.ps = _mm_cmpeq_ps(a_ps, b_ps);
+        return true;
+    case it_mm_cmplt_ps:
+        out.ps = _mm_cmplt_ps(a_ps, b_ps);
+        return true;
+    case it_mm_cmple_ps:
+        out.ps = _mm_cmple_ps(a_ps, b_ps);
+        return true;
+    case it_mm_cmpgt_ps:
+        out.ps = _mm_cmpgt_ps(a_ps, b_ps);
+        return true;
+    case it_mm_cmpge_ps:
+        out.ps = _mm_cmpge_ps(a_ps, b_ps);
+        return true;
+
+    /* Integer arithmetic */
+    case it_mm_add_epi8:
+        out.si = _mm_add_epi8(a_si, b_si);
+        return true;
+    case it_mm_add_epi16:
+        out.si = _mm_add_epi16(a_si, b_si);
+        return true;
+    case it_mm_add_epi32:
+        out.si = _mm_add_epi32(a_si, b_si);
+        return true;
+    case it_mm_add_epi64:
+        out.si = _mm_add_epi64(a_si, b_si);
+        return true;
+    case it_mm_sub_epi8:
+        out.si = _mm_sub_epi8(a_si, b_si);
+        return true;
+    case it_mm_sub_epi16:
+        out.si = _mm_sub_epi16(a_si, b_si);
+        return true;
+    case it_mm_sub_epi32:
+        out.si = _mm_sub_epi32(a_si, b_si);
+        return true;
+    case it_mm_sub_epi64:
+        out.si = _mm_sub_epi64(a_si, b_si);
+        return true;
+
+    /* Saturating arithmetic */
+    case it_mm_adds_epi8:
+        out.si = _mm_adds_epi8(a_si, b_si);
+        return true;
+    case it_mm_adds_epi16:
+        out.si = _mm_adds_epi16(a_si, b_si);
+        return true;
+    case it_mm_adds_epu8:
+        out.si = _mm_adds_epu8(a_si, b_si);
+        return true;
+    case it_mm_adds_epu16:
+        out.si = _mm_adds_epu16(a_si, b_si);
+        return true;
+    case it_mm_subs_epi8:
+        out.si = _mm_subs_epi8(a_si, b_si);
+        return true;
+    case it_mm_subs_epi16:
+        out.si = _mm_subs_epi16(a_si, b_si);
+        return true;
+    case it_mm_subs_epu8:
+        out.si = _mm_subs_epu8(a_si, b_si);
+        return true;
+    case it_mm_subs_epu16:
+        out.si = _mm_subs_epu16(a_si, b_si);
+        return true;
+
+    /* Multiply */
+    case it_mm_mullo_epi16:
+        out.si = _mm_mullo_epi16(a_si, b_si);
+        return true;
+    case it_mm_mulhi_epi16:
+        out.si = _mm_mulhi_epi16(a_si, b_si);
+        return true;
+    case it_mm_mulhi_epu16:
+        out.si = _mm_mulhi_epu16(a_si, b_si);
+        return true;
+    case it_mm_mul_epu32:
+        out.si = _mm_mul_epu32(a_si, b_si);
+        return true;
+
+    /* Shifts */
+    case it_mm_slli_epi16:
+        out.si = _mm_slli_epi16(a_si, 4);
+        return true;
+    case it_mm_slli_epi32:
+        out.si = _mm_slli_epi32(a_si, 8);
+        return true;
+    case it_mm_slli_epi64:
+        out.si = _mm_slli_epi64(a_si, 16);
+        return true;
+    case it_mm_srli_epi16:
+        out.si = _mm_srli_epi16(a_si, 4);
+        return true;
+    case it_mm_srli_epi32:
+        out.si = _mm_srli_epi32(a_si, 8);
+        return true;
+    case it_mm_srli_epi64:
+        out.si = _mm_srli_epi64(a_si, 16);
+        return true;
+    case it_mm_srai_epi16:
+        out.si = _mm_srai_epi16(a_si, 4);
+        return true;
+    case it_mm_srai_epi32:
+        out.si = _mm_srai_epi32(a_si, 8);
+        return true;
+
+    /* Logical */
+    case it_mm_and_ps:
+        out.ps = _mm_and_ps(a_ps, b_ps);
+        return true;
+    case it_mm_andnot_ps:
+        out.ps = _mm_andnot_ps(a_ps, b_ps);
+        return true;
+    case it_mm_or_ps:
+        out.ps = _mm_or_ps(a_ps, b_ps);
+        return true;
+    case it_mm_xor_ps:
+        out.ps = _mm_xor_ps(a_ps, b_ps);
+        return true;
+    case it_mm_and_si128:
+        out.si = _mm_and_si128(a_si, b_si);
+        return true;
+    case it_mm_andnot_si128:
+        out.si = _mm_andnot_si128(a_si, b_si);
+        return true;
+    case it_mm_or_si128:
+        out.si = _mm_or_si128(a_si, b_si);
+        return true;
+    case it_mm_xor_si128:
+        out.si = _mm_xor_si128(a_si, b_si);
+        return true;
+
+    /* Shuffle/permute */
+    case it_mm_shuffle_epi32:
+        out.si = _mm_shuffle_epi32(a_si, 0x1B);  // reverse
+        return true;
+    case it_mm_shufflelo_epi16:
+        out.si = _mm_shufflelo_epi16(a_si, 0x1B);
+        return true;
+    case it_mm_shufflehi_epi16:
+        out.si = _mm_shufflehi_epi16(a_si, 0x1B);
+        return true;
+    case it_mm_shuffle_ps:
+        out.ps = _mm_shuffle_ps(a_ps, b_ps, _MM_SHUFFLE(3, 2, 1, 0));
+        return true;
+
+    /* Pack/unpack */
+    case it_mm_packs_epi16:
+        out.si = _mm_packs_epi16(a_si, b_si);
+        return true;
+    case it_mm_packs_epi32:
+        out.si = _mm_packs_epi32(a_si, b_si);
+        return true;
+    case it_mm_packus_epi16:
+        out.si = _mm_packus_epi16(a_si, b_si);
+        return true;
+    case it_mm_unpackhi_epi8:
+        out.si = _mm_unpackhi_epi8(a_si, b_si);
+        return true;
+    case it_mm_unpackhi_epi16:
+        out.si = _mm_unpackhi_epi16(a_si, b_si);
+        return true;
+    case it_mm_unpackhi_epi32:
+        out.si = _mm_unpackhi_epi32(a_si, b_si);
+        return true;
+    case it_mm_unpackhi_epi64:
+        out.si = _mm_unpackhi_epi64(a_si, b_si);
+        return true;
+    case it_mm_unpacklo_epi8:
+        out.si = _mm_unpacklo_epi8(a_si, b_si);
+        return true;
+    case it_mm_unpacklo_epi16:
+        out.si = _mm_unpacklo_epi16(a_si, b_si);
+        return true;
+    case it_mm_unpacklo_epi32:
+        out.si = _mm_unpacklo_epi32(a_si, b_si);
+        return true;
+    case it_mm_unpacklo_epi64:
+        out.si = _mm_unpacklo_epi64(a_si, b_si);
+        return true;
+
+    /* Conversion */
+    case it_mm_cvtepi32_ps:
+        out.ps = _mm_cvtepi32_ps(a_si);
+        return true;
+    case it_mm_cvtps_epi32:
+        out.si = _mm_cvtps_epi32(a_ps);
+        return true;
+    case it_mm_cvttps_epi32:
+        out.si = _mm_cvttps_epi32(a_ps);
+        return true;
+
+    /* Movemask - critical for string/search ops */
+    case it_mm_movemask_epi8:
+        out.i32[0] = _mm_movemask_epi8(a_si);
+        return true;
+    case it_mm_movemask_ps:
+        out.i32[0] = _mm_movemask_ps(a_ps);
+        return true;
+
+    /* SSE4.1 */
+    case it_mm_blend_ps:
+        out.ps = _mm_blend_ps(a_ps, b_ps, 0x5);
+        return true;
+    case it_mm_blendv_ps:
+        out.ps = _mm_blendv_ps(a_ps, b_ps, _mm_cmplt_ps(a_ps, b_ps));
+        return true;
+    case it_mm_blend_epi16:
+        out.si = _mm_blend_epi16(a_si, b_si, 0x55);
+        return true;
+    case it_mm_blendv_epi8:
+        out.si = _mm_blendv_epi8(a_si, b_si, _mm_cmplt_epi8(a_si, b_si));
+        return true;
+    case it_mm_min_epi8:
+        out.si = _mm_min_epi8(a_si, b_si);
+        return true;
+    case it_mm_max_epi8:
+        out.si = _mm_max_epi8(a_si, b_si);
+        return true;
+    case it_mm_min_epu16:
+        out.si = _mm_min_epu16(a_si, b_si);
+        return true;
+    case it_mm_max_epu16:
+        out.si = _mm_max_epu16(a_si, b_si);
+        return true;
+    case it_mm_min_epi32:
+        out.si = _mm_min_epi32(a_si, b_si);
+        return true;
+    case it_mm_max_epi32:
+        out.si = _mm_max_epi32(a_si, b_si);
+        return true;
+    case it_mm_min_epu32:
+        out.si = _mm_min_epu32(a_si, b_si);
+        return true;
+    case it_mm_max_epu32:
+        out.si = _mm_max_epu32(a_si, b_si);
+        return true;
+    case it_mm_mullo_epi32:
+        out.si = _mm_mullo_epi32(a_si, b_si);
+        return true;
+
+        /* AES - if available */
+#if defined(__ARM_FEATURE_CRYPTO) || (defined(__x86_64__) || defined(__i386__))
+    case it_mm_aesenc_si128:
+        out.si = _mm_aesenc_si128(a_si, b_si);
+        return true;
+    case it_mm_aesenclast_si128:
+        out.si = _mm_aesenclast_si128(a_si, b_si);
+        return true;
+    case it_mm_aesdec_si128:
+        out.si = _mm_aesdec_si128(a_si, b_si);
+        return true;
+    case it_mm_aesdeclast_si128:
+        out.si = _mm_aesdeclast_si128(a_si, b_si);
+        return true;
+#endif
+
+    /* Skip intrinsics that require special handling */
+    default:
+        return false;
+    }
+}
+
+/* Generate golden data for a single intrinsic */
+static bool generate_golden_file(InstructionTest id,
+                                 const char *output_dir,
+                                 DifferentialTestData &data)
+{
+    float tolerance;
+    DiffCategory cat = get_diff_category(id, &tolerance);
+    if (cat == DIFF_SKIP)
+        return true;
+
+    char filepath[512];
+    snprintf(filepath, sizeof(filepath), "%s/%s.golden", output_dir,
+             instructionString[id]);
+
+    FILE *fp = fopen(filepath, "wb");
+    if (!fp) {
+        fprintf(stderr, "Failed to create: %s\n", filepath);
+        return false;
+    }
+
+    GoldenHeader header = {GOLDEN_MAGIC, GOLDEN_VERSION,
+                           static_cast<uint32_t>(id), DIFFERENTIAL_ITERATIONS};
+    if (fwrite(&header, sizeof(header), 1, fp) != 1) {
+        fprintf(stderr, "Failed to write header: %s\n", filepath);
+        fclose(fp);
+        return false;
+    }
+
+    OutputData out;
+    uint32_t valid_iterations = 0;
+    bool write_error = false;
+    for (uint32_t i = 0; i < DIFFERENTIAL_ITERATIONS; i++) {
+        data.loadIteration(
+            i * 8);  // Offset by 8 to use different data each iteration
+        if (execute_intrinsic(id, data, out)) {
+            if (fwrite(out.bytes, 16, 1, fp) != 1) {
+                write_error = true;
+                break;
+            }
+            valid_iterations++;
+        }
+    }
+
+    if (write_error) {
+        fprintf(stderr, "Failed to write data: %s\n", filepath);
+        fclose(fp);
+        remove(filepath);
+        return false;
+    }
+
+    /* Update header with actual iteration count */
+    if (valid_iterations != DIFFERENTIAL_ITERATIONS) {
+        fseek(fp, 0, SEEK_SET);
+        header.iteration_count = valid_iterations;
+        if (fwrite(&header, sizeof(header), 1, fp) != 1) {
+            fprintf(stderr, "Failed to update header: %s\n", filepath);
+            fclose(fp);
+            remove(filepath);
+            return false;
+        }
+    }
+
+    fclose(fp);
+
+    if (valid_iterations == 0) {
+        /* Remove empty file */
+        remove(filepath);
+        return true;
+    }
+
+    printf("Generated: %s (%u iterations)\n", instructionString[id],
+           valid_iterations);
+    return true;
+}
+
+/* Verify against golden data */
+static bool verify_golden_file(InstructionTest id,
+                               const char *golden_dir,
+                               DifferentialTestData &data,
+                               uint32_t *pass_count,
+                               uint32_t *fail_count)
+{
+    float tolerance;
+    DiffCategory cat = get_diff_category(id, &tolerance);
+    if (cat == DIFF_SKIP) {
+        return true;
+    }
+
+    char filepath[512];
+    snprintf(filepath, sizeof(filepath), "%s/%s.golden", golden_dir,
+             instructionString[id]);
+
+    FILE *fp = fopen(filepath, "rb");
+    if (!fp) {
+        /* No golden file - intrinsic not covered */
+        return true;
+    }
+
+    GoldenHeader header;
+    if (fread(&header, sizeof(header), 1, fp) != 1) {
+        fclose(fp);
+        return false;
+    }
+
+    if (header.magic != GOLDEN_MAGIC || header.version != GOLDEN_VERSION) {
+        fprintf(stderr, "Invalid golden file: %s\n", filepath);
+        fclose(fp);
+        return false;
+    }
+
+    OutputData golden, actual;
+    bool all_pass = true;
+
+    for (uint32_t i = 0; i < header.iteration_count; i++) {
+        if (fread(golden.bytes, 16, 1, fp) != 1) {
+            fprintf(stderr, "Truncated golden file: %s\n", filepath);
+            fclose(fp);
+            return false;
+        }
+
+        data.loadIteration(i * 8);
+        if (!execute_intrinsic(id, data, actual)) {
+            continue;  // Intrinsic not implemented in execute_intrinsic
+        }
+
+        if (!compare_output(golden, actual, cat, tolerance)) {
+            if (all_pass) {
+                fprintf(stderr, "\n%s MISMATCH at iteration %u:\n",
+                        instructionString[id], i);
+                fprintf(stderr, "  Golden: %08x %08x %08x %08x\n",
+                        golden.u32[0], golden.u32[1], golden.u32[2],
+                        golden.u32[3]);
+                fprintf(stderr, "  Actual: %08x %08x %08x %08x\n",
+                        actual.u32[0], actual.u32[1], actual.u32[2],
+                        actual.u32[3]);
+                all_pass = false;
+            }
+        }
+    }
+
+    fclose(fp);
+
+    if (all_pass) {
+        (*pass_count)++;
+        printf("PASS: %s\n", instructionString[id]);
+    } else {
+        (*fail_count)++;
+        printf("FAIL: %s\n", instructionString[id]);
+    }
+
+    return all_pass;
+}
+
+}  // namespace SSE2NEON
+
+static void print_usage(const char *prog)
+{
+    printf("Usage: %s --generate <output_dir>\n", prog);
+    printf("       %s --verify <golden_dir>\n", prog);
+    printf("\n");
+    printf("Differential Testing Harness for sse2neon\n");
+    printf("\n");
+    printf("Options:\n");
+    printf("  --generate <dir>  Generate golden reference data (run on x86)\n");
+    printf("  --verify <dir>    Verify against golden data (run on ARM)\n");
+    printf("\n");
+    printf("Known x86/ARM differences are documented in IMPROVE.md.\n");
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    bool generate_mode = (strcmp(argv[1], "--generate") == 0);
+    bool verify_mode = (strcmp(argv[1], "--verify") == 0);
+
+    if (!generate_mode && !verify_mode) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    const char *dir = argv[2];
+
+    if (generate_mode) {
+        if (!SSE2NEON::ensure_directory(dir)) {
+            fprintf(stderr, "Failed to create directory: %s\n", dir);
+            return 1;
+        }
+    }
+
+    SSE2NEON::DifferentialTestData data;
+
+    printf("sse2neon Differential Testing\n");
+    printf("==============================\n");
+#if defined(__x86_64__) || defined(__i386__)
+    printf("Platform: x86 (native SSE)\n");
+#elif defined(__aarch64__) || defined(__arm__)
+    printf("Platform: ARM (sse2neon)\n");
+#else
+    printf("Platform: unknown\n");
+#endif
+    printf("Mode: %s\n", generate_mode ? "generate" : "verify");
+    printf("Directory: %s\n", dir);
+    printf("\n");
+
+    uint32_t pass_count = 0;
+    uint32_t fail_count = 0;
+    uint32_t skip_count = 0;
+
+    for (uint32_t i = 0; i < SSE2NEON::it_last; i++) {
+        SSE2NEON::InstructionTest id =
+            static_cast<SSE2NEON::InstructionTest>(i);
+
+        float tolerance;
+        SSE2NEON::DiffCategory cat =
+            SSE2NEON::get_diff_category(id, &tolerance);
+        if (cat == SSE2NEON::DIFF_SKIP) {
+            skip_count++;
+            continue;
+        }
+
+        if (generate_mode) {
+            SSE2NEON::generate_golden_file(id, dir, data);
+        } else {
+            SSE2NEON::verify_golden_file(id, dir, data, &pass_count,
+                                         &fail_count);
+        }
+    }
+
+    printf("\n");
+    printf("==============================\n");
+    if (verify_mode) {
+        printf("Results: %u passed, %u failed, %u skipped\n", pass_count,
+               fail_count, skip_count);
+    } else {
+        printf("Golden data generated in: %s\n", dir);
+    }
+
+    return fail_count > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Implement a differential testing harness that compares NEON outputs against x86 SSE golden reference data to catch semantic drift.

Components:
- tests/differential.cpp: Standalone harness covering 96 intrinsics
- scripts/generate-golden.py: Python wrapper for x86 golden generation
- CI jobs: differential-x86 generates golden, differential-arm verifies

Features:
- Binary golden format with magic/version header validation
- Tolerance categories for known differences (DIFF_FLOAT_TOLERANCE, DIFF_NAN_HANDLING, DIFF_SKIP)
- Deterministic PRNG (seed=123456) ensures identical inputs cross-platform
- AES intrinsics included with FEATURE=crypto+crc on ARM

Also fixes Makefile bug where FEATURE flag was silently ignored due to missing 'override' keyword after initial ARCH_CFLAGS assignment.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a differential testing harness to compare sse2neon outputs on ARM against x86 SSE golden data to catch semantic drift. CI now generates golden data on x86 and verifies on ARM; also fixes FEATURE flag handling in the Makefile.

- **New Features**
  - Standalone harness (tests/differential.cpp) with binary golden format (magic/version) and 100-iteration runs for 90+ intrinsics.
  - Handles known differences via categories: float tolerance, NaN handling, and skip.
  - gen-golden script (scripts/gen-golden.py) to build and emit golden data on x86.
  - Makefile targets: generate-golden (x86) and check-differential (ARM); AES included via FEATURE=crypto+crc.
  - CI: differential-x86 job builds and uploads golden data; differential-arm downloads and verifies.

- **Bug Fixes**
  - Makefile now uses override for ARCH_CFLAGS so FEATURE is respected.

<sup>Written for commit b713a57ef66c29e2a34833acec5a49cca0c48f1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





