### PR TITLE
CI: Add uninitialized variable warning checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,6 +241,15 @@ jobs:
             --gcc-toolchain=/usr \
             -isystem /usr/aarch64-linux-gnu/include \
             -march=armv8-a+simd+crypto+crc
+      - name: uninitialized variable warnings
+        run: |
+          # Check for uninitialized variable warnings
+          COMMON="-fsyntax-only -Werror -Wuninitialized -Wall -std=gnu++14 -I. -march=armv8-a+simd+crypto+crc"
+          # GCC: -Wmaybe-uninitialized is stricter than Clang's -Wuninitialized
+          aarch64-linux-gnu-g++ $COMMON -Wmaybe-uninitialized tests/main.cpp
+          # Clang: cross-compile targeting AArch64
+          clang++-$LLVM_VERSION $COMMON --target=aarch64-linux-gnu \
+            --gcc-toolchain=/usr -isystem /usr/aarch64-linux-gnu/include tests/main.cpp
 
   # iOS build verification
   host-ios:


### PR DESCRIPTION
Makefile: Add check_cxx_flag() for compiler flag detection and EXTRA_WARNINGS=uninit support with 'make check-uninit' target.

CI: Add uninitialized warning step to static-analysis job using both GCC (`-Wmaybe-uninitialized`) and Clang cross-compilers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds uninitialized variable warning checks to CI and the build to catch potential bugs early. Adds a make target and flag detection to enforce -Wuninitialized/-Wmaybe-uninitialized across GCC and Clang.

- **New Features**
  - CI static-analysis step compiles tests with -Werror and uninit warnings on GCC (-Wmaybe-uninitialized) and Clang, targeting AArch64.
  - Makefile adds check_cxx_flag to detect supported warning flags and EXTRA_WARNINGS=uninit to enable them.
  - New make target: check-uninit to run tests with strict uninitialized checks.

<sup>Written for commit 38277674d5401c6243266666b2daac54c1de268e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

