### PR TITLE
CI: Skip unnecessary clang installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,13 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v6
-      - name: install build dependencies
+      - name: install clang
+        if: contains(matrix.cxx_compiler, 'clang')
         run: |
           sudo apt-get update -q -y
-          sudo apt-get install -q -y clang-18
+          sudo apt-get install -q -y "${CXX_COMPILER/clang++/clang}"
+        env:
+          CXX_COMPILER: ${{ matrix.cxx_compiler }}
       - name: build artifact
         env:
           CXX: ${{ matrix.cxx_compiler }}
@@ -84,10 +87,13 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v6
-      - name: install build dependencies
+      - name: install clang
+        if: contains(matrix.cxx_compiler, 'clang')
         run: |
           sudo apt-get update -q -y
-          sudo apt-get install -q -y clang-18
+          sudo apt-get install -q -y "${CXX_COMPILER/clang++/clang}"
+        env:
+          CXX_COMPILER: ${{ matrix.cxx_compiler }}
       - name: build and test
         env:
           CXX: ${{ matrix.cxx_compiler }}
@@ -176,17 +182,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        include:
-          - sanitizer: undefined
-            cxx_compiler: g++
-          - sanitizer: address
-            cxx_compiler: g++
+        sanitizer: [undefined, address]
     steps:
       - name: checkout code
         uses: actions/checkout@v6
       - name: build and test with sanitizer
         env:
-          CXX: ${{ matrix.cxx_compiler }}
+          CXX: g++
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=1
         run: make FEATURE=crypto+crc SANITIZE=${{ matrix.sanitizer }} check
@@ -196,17 +198,13 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        include:
-          - sanitizer: undefined
-            cxx_compiler: g++
-          - sanitizer: address
-            cxx_compiler: g++
+        sanitizer: [undefined, address]
     steps:
       - name: checkout code
         uses: actions/checkout@v6
       - name: build and test with sanitizer
         env:
-          CXX: ${{ matrix.cxx_compiler }}
+          CXX: g++
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=1
         run: make SANITIZE=${{ matrix.sanitizer }} check


### PR DESCRIPTION
- Make clang install conditional on compiler selection
- Derive package name from matrix variable (version-agnostic)
- Simplify sanitizer matrices by removing redundant variables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip installing clang in CI unless a clang compiler is selected. Also simplify sanitizer jobs to reduce config and speed up builds.

- **Refactors**
  - Install clang only when the matrix compiler is clang; derive the apt package name from the compiler (version-agnostic).
  - Remove redundant cxx_compiler entries in sanitizer matrices; set CXX=g++ and use a simple sanitizer list.

<sup>Written for commit f2961fb6837fdfb79bcf7edc68bb28ff6091ff17. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

