### PR TITLE
Add MXCSR exception flag macros for compatibility

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -12,6 +12,7 @@
  * as a union type. sse2neon.h blocks these headers by pre-defining their
  * include guards, but this only works if sse2neon.h is included first.
  */
+
 #if defined(_M_ARM64EC)
 #include "sse2neon.h"
 #endif
@@ -40,6 +41,43 @@
 #define _MM_DENORMALS_ZERO_MASK 0x0040
 #define _MM_DENORMALS_ZERO_ON 0x0040
 #define _MM_DENORMALS_ZERO_OFF 0x0000
+#endif
+
+// Fallback definitions for exception flag macros (MXCSR bits 0-5)
+#ifndef _MM_EXCEPT_INVALID
+#define _MM_EXCEPT_INVALID 0x0001
+#define _MM_EXCEPT_DENORM 0x0002
+#define _MM_EXCEPT_DIV_ZERO 0x0004
+#define _MM_EXCEPT_OVERFLOW 0x0008
+#define _MM_EXCEPT_UNDERFLOW 0x0010
+#define _MM_EXCEPT_INEXACT 0x0020
+#define _MM_EXCEPT_MASK 0x003F
+#endif
+#ifndef _MM_MASK_INVALID
+#define _MM_MASK_INVALID 0x0080
+#define _MM_MASK_DENORM 0x0100
+#define _MM_MASK_DIV_ZERO 0x0200
+#define _MM_MASK_OVERFLOW 0x0400
+#define _MM_MASK_UNDERFLOW 0x0800
+#define _MM_MASK_INEXACT 0x1000
+#define _MM_MASK_MASK 0x1F80
+#endif
+
+// Fallback definitions for exception state/mask accessor macros (x86)
+// On x86, these read/write the actual MXCSR exception bits
+#ifndef _MM_GET_EXCEPTION_STATE
+#define _MM_GET_EXCEPTION_STATE() (_mm_getcsr() & _MM_EXCEPT_MASK)
+#endif
+#ifndef _MM_SET_EXCEPTION_STATE
+#define _MM_SET_EXCEPTION_STATE(x) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_EXCEPT_MASK) | ((x) & _MM_EXCEPT_MASK))
+#endif
+#ifndef _MM_GET_EXCEPTION_MASK
+#define _MM_GET_EXCEPTION_MASK() (_mm_getcsr() & _MM_MASK_MASK)
+#endif
+#ifndef _MM_SET_EXCEPTION_MASK
+#define _MM_SET_EXCEPTION_MASK(x) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_MASK_MASK) | ((x) & _MM_MASK_MASK))
 #endif
 
 // __int64 is defined in the Intrinsics Guide which maps to different datatype


### PR DESCRIPTION
MXCSR exception flags (bits 0-5) and masks (bits 7-12) are NOT emulated on NEON, as ARM lacks sticky exception flags.
- Define _MM_EXCEPT_* macros (INVALID, DENORM, DIV_ZERO, OVERFLOW, UNDERFLOW, INEXACT) with Intel-spec values
- Define _MM_MASK_* macros for exception masks
- Add silent stub accessor macros (_MM_GET/SET_EXCEPTION_STATE/MASK)

The accessor macros return safe defaults: GET_EXCEPTION_STATE returns 0 (no exceptions), GET_EXCEPTION_MASK returns 0x1F80 (all masked), and SET operations are no-ops.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MXCSR exception flag and mask macros to sse2neon for API compatibility on ARM, with stub accessors that return safe defaults and no-ops so existing SSE code compiles without relying on unsupported flags.

- **New Features**
  - Define _MM_EXCEPT_* and _MM_MASK_* macros with Intel-spec values.
  - Add _MM_GET/SET_EXCEPTION_STATE and _MM_GET/SET_EXCEPTION_MASK; on ARM: GET state = 0, GET mask = 0x1F80, SET are no-ops.
  - Clarify _mm_setcsr/_mm_getcsr behavior: rounding/FZ/DAZ supported; exception bits ignored; DAZ mirrors FZ on ARM.
  - Add tests to verify macro values and ARM behavior; include x86 fallbacks in test helpers.

<sup>Written for commit 582431694bc9804dfedac36bfe053775cf5178a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

