### PR TITLE
Add _mm_monitor and _mm_mwait SSE3 intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,21 @@ Define these macros as `1` before including `sse2neon.h` to enable precise (but 
 | `SSE2NEON_PRECISE_SQRT` | Extra Newton-Raphson iteration for `_mm_sqrt_ps` and `_mm_rsqrt_ps` |
 | `SSE2NEON_PRECISE_DP` | Conditional multiplication in `_mm_dp_pd` |
 
-All flags are disabled by default to maximize performance.
+All precision flags are disabled by default to maximize performance.
+
+### MONITOR/MWAIT Policy
+
+ARM has no userspace equivalent for x86 address-range monitoring.
+`_mm_monitor` is a no-op; `_mm_mwait` behavior is controlled by `SSE2NEON_MWAIT_POLICY`:
+
+| Value | Behavior |
+|-------|----------|
+| `0` (default) | `yield` - Safe everywhere, never blocks |
+| `1` | `wfe` - Event wait, may trap in EL0 |
+| `2` | `wfi` - Interrupt wait, may trap in EL0 |
+
+Policies 1/2 do not provide "wake on store" semantics and may trap on Linux/iOS/macOS.
+See `sse2neon.h` for detailed usage guidance.
 
 ## Run Built-in Test Suite
 

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -8093,6 +8093,22 @@ result_t test_mm_loaddup_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
     return VALIDATE_DOUBLE_M128(ret, d);
 }
 
+result_t test_mm_monitor(const SSE2NEONTestImpl &impl, uint32_t iter)
+{
+    // _mm_monitor is a hint instruction with no visible side effects.
+    // On ARM, it's implemented as a no-op since there's no equivalent
+    // userspace address-monitoring mechanism.
+    // On x86, MONITOR requires CPL0 (kernel mode) and traps in user space.
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || \
+    defined(_M_ARM)
+    int dummy = 42;
+    _mm_monitor(&dummy, 0, 0);
+    return TEST_SUCCESS;
+#else
+    return TEST_UNIMPL;
+#endif
+}
+
 result_t test_mm_movedup_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     const double *p = reinterpret_cast<const double *>(impl.mTestFloatPointer1);
@@ -8115,6 +8131,21 @@ result_t test_mm_moveldup_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
     const float *p = impl.mTestFloatPointer1;
     __m128 a = load_m128(p);
     return validateFloat(_mm_moveldup_ps(a), p[0], p[0], p[2], p[2]);
+}
+
+result_t test_mm_mwait(const SSE2NEONTestImpl &impl, uint32_t iter)
+{
+    // _mm_mwait is a hint instruction for power-saving wait states.
+    // On ARM, it's implemented as yield (default), wfe, or wfi depending
+    // on SSE2NEON_MWAIT_POLICY. This test validates API presence.
+    // On x86, MWAIT requires CPL0 (kernel mode) and traps in user space.
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || \
+    defined(_M_ARM)
+    _mm_mwait(0, 0);
+    return TEST_SUCCESS;
+#else
+    return TEST_UNIMPL;
+#endif
 }
 
 /* SSSE3 */

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -404,9 +404,11 @@
     _(mm_hsub_ps)                 \
     _(mm_lddqu_si128)             \
     _(mm_loaddup_pd)              \
+    _(mm_monitor)                 \
     _(mm_movedup_pd)              \
     _(mm_movehdup_ps)             \
     _(mm_moveldup_ps)             \
+    _(mm_mwait)                   \
     /* SSSE3 */                   \
     _(mm_abs_epi16)               \
     _(mm_abs_epi32)               \


### PR DESCRIPTION
This implements the final two SSE3 intrinsics for complete coverage:
* `_mm_monitor`: No-op (ARM has no userspace address-range monitoring)
* `_mm_mwait`: Policy-based low-power hint via `SSE2NEON_MWAIT_POLICY`
  - Policy 0 (default): yield - safe everywhere
  - Policy 1: wfe - event wait, may trap in EL0
  - Policy 2: wfi - interrupt wait, may trap in EL0

It uses ARM ACLE intrinsics (`__yield`, `__wfe`, `__wfi`) consistently:
* arm_acle.h for GCC/Clang on ARMv8+
* intrin.h for MSVC on ARM/ARM64
* Inline asm fallback for ARMv7 non-MSVC