### PR TITLE
Implement _mm_undefined_* control

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Define these macros as `1` before including `sse2neon.h` to enable precise (but 
 | `SSE2NEON_PRECISE_DIV` | Extra Newton-Raphson iteration for `_mm_rcp_ps` and `_mm_div_ps` |
 | `SSE2NEON_PRECISE_SQRT` | Extra Newton-Raphson iteration for `_mm_sqrt_ps` and `_mm_rsqrt_ps` |
 | `SSE2NEON_PRECISE_DP` | Conditional multiplication in `_mm_dp_pd` |
+| `SSE2NEON_UNDEFINED_ZERO` | Force zero for `_mm_undefined_{ps,pd,si128}` (MSVC already does this) |
 
 All precision flags are disabled by default to maximize performance.
 

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3543,6 +3543,22 @@ result_t test_mm_ucomineq_ss(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_undefined_ps(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     __m128 a = _mm_undefined_ps();
+
+    // When SSE2NEON_UNDEFINED_ZERO is set or on MSVC, the value should be zero.
+    // On GCC/Clang without the flag, the value is truly undefined so we can
+    // only test that XOR-with-self produces zero.
+#if SSE2NEON_UNDEFINED_ZERO || (defined(_MSC_VER) && !defined(__clang__))
+    result_t res = validateFloat(a, 0, 0, 0, 0);
+    if (res != TEST_SUCCESS)
+        return res;
+#else
+    // Use volatile barrier to prevent compiler from optimizing away the
+    // undefined value. This forces materialization and avoids UB from
+    // reading uninitialized memory directly.
+    volatile __m128 barrier = a;
+    a = barrier;
+#endif
+
     a = _mm_xor_ps(a, a);
     return validateFloat(a, 0, 0, 0, 0);
 }
@@ -7700,6 +7716,23 @@ result_t test_mm_ucomineq_sd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_undefined_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     __m128d a = _mm_undefined_pd();
+
+    // When SSE2NEON_UNDEFINED_ZERO is set or on MSVC, the value should be zero.
+    // On GCC/Clang without the flag, the value is truly undefined so we can
+    // only test that XOR-with-self produces zero.
+#if SSE2NEON_UNDEFINED_ZERO || (defined(_MSC_VER) && !defined(__clang__))
+    double zero[2] = {0, 0};
+    result_t res = VALIDATE_DOUBLE_M128(a, zero);
+    if (res != TEST_SUCCESS)
+        return res;
+#else
+    // Use volatile barrier to prevent compiler from optimizing away the
+    // undefined value. This forces materialization and avoids UB from
+    // reading uninitialized memory directly.
+    volatile __m128d barrier = a;
+    a = barrier;
+#endif
+
     a = _mm_xor_pd(a, a);
     double d[2] = {0, 0};
     return VALIDATE_DOUBLE_M128(a, d);
@@ -7708,6 +7741,23 @@ result_t test_mm_undefined_pd(const SSE2NEONTestImpl &impl, uint32_t iter)
 result_t test_mm_undefined_si128(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
     __m128i a = _mm_undefined_si128();
+
+    // When SSE2NEON_UNDEFINED_ZERO is set or on MSVC, the value should be zero.
+    // On GCC/Clang without the flag, the value is truly undefined so we can
+    // only test that XOR-with-self produces zero.
+#if SSE2NEON_UNDEFINED_ZERO || (defined(_MSC_VER) && !defined(__clang__))
+    int64_t zero[2] = {0, 0};
+    result_t res = VALIDATE_INT64_M128(a, zero);
+    if (res != TEST_SUCCESS)
+        return res;
+#else
+    // Use volatile barrier to prevent compiler from optimizing away the
+    // undefined value. This forces materialization and avoids UB from
+    // reading uninitialized memory directly.
+    volatile __m128i barrier = a;
+    a = barrier;
+#endif
+
     a = _mm_xor_si128(a, a);
     int64_t d[2] = {0, 0};
     return VALIDATE_INT64_M128(a, d);


### PR DESCRIPTION
MSVC on ARM forces zero-initialization for _mm_undefined_ps/pd/si128, diverging from x86 behavior where garbage values are returned. GCC/Clang match x86 by returning uninitialized memory.

This adds SSE2NEON_UNDEFINED_ZERO macro for explicit control:
- Default (0): Compiler-dependent (MSVC=zero, GCC/Clang=undefined)
- Enabled (1): Force zero-initialization on all compilers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added SSE2NEON_UNDEFINED_ZERO to control _mm_undefined_ps/_pd/_si128 behavior. Set it to 1 to force zero on all compilers; default keeps MSVC=zero and GCC/Clang=undefined.

- **New Features**
  - Implemented conditional zero for _mm_undefined_* and documented the macro in README.
  - Updated tests to verify zero when enabled or on MSVC, and to safely handle undefined values via a volatile barrier.

- **Migration**
  - Optional: define SSE2NEON_UNDEFINED_ZERO as 1 before including sse2neon.h to get deterministic zero-initialization.

<sup>Written for commit a416add4e0d3326a18232e3803dedccc5ffe239f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

