### PR TITLE
Document _mm_malloc/_mm_free allocation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Define these macros as `1` before including `sse2neon.h` to enable precise (but 
 
 All precision flags are disabled by default to maximize performance.
 
+### Memory Allocation
+
+Memory from `_mm_malloc()` must be freed with `_mm_free()`, not `free()`. Mixing allocators causes heap corruption on Windows.
+
 ### MONITOR/MWAIT Policy
 
 ARM has no userspace equivalent for x86 address-range monitoring.


### PR DESCRIPTION
This warns that memory from _mm_malloc() must be freed with _mm_free(), not standard free(). On Windows, mixing allocators corrupts the heap because _aligned_malloc/_aligned_free must be paired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the allocation contract for _mm_malloc/_mm_free and warns against mixing allocators. Adds clear notes in README and sse2neon.h to prevent Windows heap corruption.

- **Migration**
  - Replace free/delete with _mm_free for pointers from _mm_malloc.
  - Keep this pairing on all platforms to remain Windows-safe.

<sup>Written for commit ef884a0f06c13f3c94e5236d07db1bf4cd19881c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

