### PR TITLE
Fix Clang compatibility for alignr intrinsics

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -5390,10 +5390,10 @@ result_t test_mm_cvttsd_si64(const SSE2NEONTestImpl &impl, uint32_t iter)
 
 result_t test_mm_cvttsd_si64x(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
-#if defined(__clang__)
-    // The intrinsic _mm_cvttsd_si64x() does not exist in Clang
-    return TEST_UNIMPL;
-#else
+    // _mm_cvttsd_si64x is an alias defined only in sse2neon.h, not in native
+    // x86 SSE headers. Only test on ARM where sse2neon provides this macro.
+#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || \
+    defined(_M_ARM64EC)
     const double *_a =
         reinterpret_cast<const double *>(impl.mTestFloatPointer1);
 
@@ -5402,6 +5402,10 @@ result_t test_mm_cvttsd_si64x(const SSE2NEONTestImpl &impl, uint32_t iter)
 
     return ret == sse2neon_saturate_cast_int64(_a[0]) ? TEST_SUCCESS
                                                       : TEST_FAIL;
+#else
+    (void) impl;
+    (void) iter;
+    return TEST_UNIMPL;
 #endif
 }
 
@@ -8341,9 +8345,6 @@ result_t test_mm_abs_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 
 result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
-#if defined(__clang__)
-    return TEST_UNIMPL;
-#else
     const uint8_t *_a =
         reinterpret_cast<const uint8_t *>(impl.mTestIntPointer1);
     const uint8_t *_b =
@@ -8387,14 +8388,10 @@ result_t test_mm_alignr_epi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
 
     return VALIDATE_UINT8_M128(ret, d);
-#endif
 }
 
 result_t test_mm_alignr_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
 {
-#if defined(__clang__)
-    return TEST_UNIMPL;
-#else
     const uint8_t *_a =
         reinterpret_cast<const uint8_t *>(impl.mTestIntPointer1);
     const uint8_t *_b =
@@ -8433,7 +8430,6 @@ result_t test_mm_alignr_pi8(const SSE2NEONTestImpl &impl, uint32_t iter)
     }
 
     return VALIDATE_UINT8_M64(ret, d);
-#endif
 }
 
 result_t test_mm_hadd_epi16(const SSE2NEONTestImpl &impl, uint32_t iter)


### PR DESCRIPTION
- Fix `_mm_alignr_pi8`: Split into GCC/Clang paths to handle Clang's strict compile-time validation of vext_u8 arguments. This uses `((imm) - 8) & 7` masking to ensure valid range [0,7] even in unreachable branches.

- Fix _mm_alignr_epi8: Change `_mm_srli_si128(_a,...)` to `_mm_srli_si128((a),...)` to avoid variable shadowing in nested `__extension__` statement expressions.

- Remove #`if defined(__clang__)` test skips for `_mm_cvttsd_si64x`, `_mm_alignr_epi8`, and `_mm_alignr_pi8` as implementations now work correctly with Clang.

Test coverage increases from 99.4% to 100% (525 tests, 0 skipped).



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make alignr intrinsics work on Clang by splitting GCC/Clang/MSVC implementations and fixing immediate handling and shadowing. Remove Clang test skips; guard _mm_cvttsd_si64x for ARM; test coverage is 100%.

- **Bug Fixes**
  - _mm_alignr_pi8: split GCC/Clang; GCC uses (imm) - 8; Clang masks ((imm) - 8) & 7 and (imm) & 7.
  - _mm_alignr_epi8: split GCC/Clang/MSVC; inline vextq_* for imm >= 16; avoid shadowing and double evaluation.
  - Tests: remove Clang-only skips for _mm_alignr_epi8 and _mm_alignr_pi8; guard _mm_cvttsd_si64x to ARM (incl. _M_ARM64EC).

<sup>Written for commit 8e1850c0bdb11a94a67a4cb460ebdf3d730981a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



