### PR TITLE
Remove defined(_BIG_ENDIAN) from endianness check

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -348,8 +348,7 @@
  */
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
 #error "sse2neon requires little-endian target; big-endian is not supported"
-#elif defined(__ARMEB__) || defined(__AARCH64EB__) || \
-    defined(__BIG_ENDIAN__) || defined(_BIG_ENDIAN)
+#elif defined(__ARMEB__) || defined(__AARCH64EB__) || defined(__BIG_ENDIAN__)
 #error "sse2neon requires little-endian target; big-endian is not supported"
 #endif
 


### PR DESCRIPTION
On FreeBSD, <sys/_endian.h> unconditionally defines _BIG_ENDIAN as a constant value (4321) to be tested against _BYTE_ORDER, regardless of whether we are on a big or little endian target. This caused spurious compile errors on little-endian FreeBSD systems.

The remaining checks (`__BYTE_ORDER__`, `__ARMEB__`, `__AARCH64EB__`, `__BIG_ENDIAN__`) are sufficient to detect big-endian targets.

Close #752



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed _BIG_ENDIAN from the endianness check to stop false big-endian detection on little-endian FreeBSD and fix compile errors.

- **Bug Fixes**
  - FreeBSD defines _BIG_ENDIAN as a constant (4321), which wrongly triggered the big-endian path. Detection now relies on __BYTE_ORDER__, __ARMEB__, __AARCH64EB__, and __BIG_ENDIAN__.

<sup>Written for commit 779caaae82950b367887bff9fe6546324c1a70f0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



