### PR TITLE
CI: Fix clang-18 installation on ARM64 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
       - name: install clang
         if: contains(matrix.cxx_compiler, 'clang')
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get install -q -y "${CXX_COMPILER/clang++/clang}"
+          sudo apt-get -o Acquire::Retries=5 update -q -y
+          sudo apt-get -o Acquire::Retries=5 install -q -y --no-install-recommends "${CXX_COMPILER/clang++/clang}"
         env:
           CXX_COMPILER: ${{ matrix.cxx_compiler }}
       - name: build artifact
@@ -90,8 +90,10 @@ jobs:
       - name: install clang
         if: contains(matrix.cxx_compiler, 'clang')
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get install -q -y "${CXX_COMPILER/clang++/clang}"
+          # clang-18 is in 'universe' repository on Ubuntu 24.04
+          sudo add-apt-repository -y -n universe
+          sudo apt-get -o Acquire::Retries=5 update -q -y
+          sudo apt-get -o Acquire::Retries=5 install -q -y --no-install-recommends "${CXX_COMPILER/clang++/clang}"
         env:
           CXX_COMPILER: ${{ matrix.cxx_compiler }}
       - name: build and test


### PR DESCRIPTION
The ubuntu-24.04-arm runner does not have clang-18 in its default apt repositories, causing host-arm-native job to fail with exit code 100.

Fix by enabling the Ubuntu 'universe' repository where clang-18 is available for arm64 architecture.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI failures on the Ubuntu 24.04 ARM64 runner by enabling the “universe” repo and hardening apt commands so clang-18 installs reliably. This unblocks the host-arm-native job.

- **Bug Fixes**
  - Enable Ubuntu “universe” on ARM jobs to make clang-18 available for arm64.
  - Add apt-get retries and --no-install-recommends to reduce transient install failures and avoid extra packages.

<sup>Written for commit c121d502283f9ec734649938db65738c2c58f235. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



