### PR TITLE
mm_cmpistrm: fix one test that wasn't being run

### DIFF
--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -12436,7 +12436,7 @@ static test_mm_cmpistrm_sword_data_t
         {
             {-39, -10, 17, 89, 998, 1000, 1234, 4566},
             {-40, -52, -39, -29, 100, 1024, 4565, 4600},
-            IMM_SWORD_RANGES_BIT,
+            IMM_SWORD_RANGES_UNIT,
             {0, 0, -1, -1, 0, 0, -1, 0},
         },
         {


### PR DESCRIPTION
The test data is indeed unit and not bit based.

The previous bad test wasn't being run as "SWORD_RANGES_UNIT" is specified on line 12481, and so the test using "SWORD_RANGES_BIT" wasn't triggered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misconfigured mm_cmpistrm SWORD range test so it runs in the correct mode. Replaces IMM_SWORD_RANGES_BIT with IMM_SWORD_RANGES_UNIT to match the unit-based data.

- **Bug Fixes**
  - Switched the test immediate to IMM_SWORD_RANGES_UNIT in tests/impl.cpp.
  - The suite runs SWORD_RANGES_UNIT, so the BIT-based test never executed; this now validates the intended case.

<sup>Written for commit 6cbcc1aea7331525278e9c20bde32eb71a879717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

