### PR TITLE
perf: Reduce instructions for `_mm_movemask_epi8`

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -5778,7 +5778,6 @@ FORCE_INLINE int _mm_movemask_epi8(__m128i a)
     //
     // Step 1: Extract MSB of each byte
     uint8x16_t msbs = vshrq_n_u8(input, 7);
-    uint64x2_t bits = vreinterpretq_u64_u8(msbs);
 
     // Step 2: Parallel bit collection via shift-right-accumulate
     //
@@ -5794,13 +5793,22 @@ FORCE_INLINE int _mm_movemask_epi8(__m128i a)
     //
     //   vsra(..., 14): combine pairs -> 4 bits in bytes 3,7
     //   vsra(..., 28): combine all   -> 8 bits in byte 7 (actually byte 0)
+    uint64x2_t bits = vreinterpretq_u64_u8(msbs);
     bits = vsraq_n_u64(bits, bits, 7);
     bits = vsraq_n_u64(bits, bits, 14);
     bits = vsraq_n_u64(bits, bits, 28);
 
     // Step 3: Extract packed result from byte 0 of each half
     uint8x16_t output = vreinterpretq_u8_u64(bits);
-    return vgetq_lane_u8(output, 0) | (vgetq_lane_u8(output, 8) << 8);
+
+    // Step 4: Extract the high byte (position 8) and write it into lane 1,
+    // right next to the untouched low byte at lane 0.
+    unsigned char output_high = vgetq_lane_u8(output, 8);
+    output = vsetq_lane_u8(output_high, output, 1);
+
+    // Step 5: Reinterpret so lanes 0 and 1 form a single 16-bit element.
+    uint16x8_t combined = vreinterpretq_u16_u8(output);
+    return _sse2neon_static_cast(int, vgetq_lane_u16(combined, 0));
 #endif
 }
 


### PR DESCRIPTION
Hi

Instead of extracting both bytes into scalar registers and combining them via bitwise operations, we copy the high byte directly into place and extract the 16-bit result. This avoids scalar bitwise logic, cuts cross-register transfer overhead, and reduces generated assembly from 7 to 6 instructions (`umov + umov + orr` → `ins + umov`). Also added the missing return value cast via `_sse2neon_static_cast`.

You can find a direct comparison here: https://godbolt.org/z/s1Gqs5EP7

## Original
```c
uint8x16_t msbs = vshrq_n_u8(input, 7);
uint64x2_t bits = vreinterpretq_u64_u8(msbs);
bits = vsraq_n_u64(bits, bits, 7);
bits = vsraq_n_u64(bits, bits, 14);
bits = vsraq_n_u64(bits, bits, 28);
uint8x16_t output = vreinterpretq_u8_u64(bits);
return vgetq_lane_u8(output, 0) | (vgetq_lane_u8(output, 8) << 8);
```
```Rust
_mm_movemask_epi8(__Int64x2_t):
        ushr    v0.16b, v0.16b, 7
        usra    v0.2d, v0.2d, 7
        usra    v0.2d, v0.2d, 14
        usra    v0.2d, v0.2d, 28
        umov    w1, v0.b[8]
        umov    w0, v0.b[0]
        orr     w0, w0, w1, lsl 8
        ret
```

## Improved
```c
uint8x16_t msbs = vshrq_n_u8(input, 7);
uint64x2_t bits = vreinterpretq_u64_u8(msbs);
bits = vsraq_n_u64(bits, bits, 7);
bits = vsraq_n_u64(bits, bits, 14);
bits = vsraq_n_u64(bits, bits, 28);
uint8x16_t output = vreinterpretq_u8_u64(bits);
unsigned char output_high = vgetq_lane_u8(output, 8);
output = vsetq_lane_u8(output_high, output, 1);
uint16x8_t combined = vreinterpretq_u16_u8(output);
return _sse2neon_static_cast(int, vgetq_lane_u16(combined, 0));
```
```Rust
_mm_movemask_epi8(__Int64x2_t):
        ushr    v0.16b, v0.16b, 7
        usra    v0.2d, v0.2d, 7
        usra    v0.2d, v0.2d, 14
        usra    v0.2d, v0.2d, 28
        ins     v0.b[1], v0.b[8]
        umov    w0, v0.h[0]
        ret
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize `_mm_movemask_epi8` in `sse2neon.h` to remove scalar bitwise ops and cut AArch64 codegen from 7 to 6 instructions with no behavior change. Also adds an explicit `_sse2neon_static_cast` on the return value.

- **Refactors**
  - Replace `umov + umov + orr` with `ins + umov` by moving the high byte into lane 1 and extracting the 16-bit lane.
  - Preserve the existing shift-right-accumulate pipeline; only the final extract path changed.

<sup>Written for commit de922ea5c2ad1ff7fc84a9ab75c352646184f4a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DLTcollab/sse2neon/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

