### PR TITLE
Add Linux A32/A64 benchmark workflows

### DIFF
--- a/.github/workflows/benchmark-linux-a32.yml
+++ b/.github/workflows/benchmark-linux-a32.yml
@@ -1,0 +1,59 @@
+name: Benchmark Linux A32
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Run benchmark on Linux A32
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6:armhf libstdc++6:armhf cmake
+
+      - name: Cache Benchmark library
+        uses: actions/cache@v4
+        with:
+          path: benchmark
+          key: ${{ runner.os }}-googlebenchmark-v1.8.3
+
+      - name: Build Google Benchmark
+        run: |
+          if [ ! -d "benchmark/build" ]; then
+            git clone --branch v1.8.3 --depth 1 https://github.com/google/benchmark.git
+            cd benchmark
+            cmake -E make_directory "build"
+            cmake -E chdir "build" cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DBENCHMARK_ENABLE_TESTING=OFF -DBENCHMARK_ENABLE_LTO=true ..
+            cmake --build "build" --config Release
+          fi
+          
+      - name: Build benchmark
+        run: |
+          arm-linux-gnueabihf-g++ -O2 -mfpu=neon -I. -I./benchmark/include -L./benchmark/build/src -std=gnu++14 -o tests/bench_movemask tests/bench_movemask.cpp -lbenchmark -lpthread -lrt
+
+      - name: Run benchmark
+        run: |
+          ./tests/bench_movemask --benchmark_format=json | tee benchmark.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'googlecpp'
+          output-file-path: benchmark.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true

--- a/.github/workflows/benchmark-linux-a64.yml
+++ b/.github/workflows/benchmark-linux-a64.yml
@@ -1,0 +1,58 @@
+name: Benchmark Linux A64
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Run benchmark on Linux A64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ cmake
+
+      - name: Cache Benchmark library
+        uses: actions/cache@v4
+        with:
+          path: benchmark
+          key: ${{ runner.os }}-googlebenchmark-a64-v1.8.3
+
+      - name: Build Google Benchmark
+        run: |
+          if [ ! -d "benchmark/build" ]; then
+            git clone --branch v1.8.3 --depth 1 https://github.com/google/benchmark.git
+            cd benchmark
+            cmake -E make_directory "build"
+            cmake -E chdir "build" cmake -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=OFF -DBENCHMARK_ENABLE_LTO=true ..
+            cmake --build "build" --config Release
+          fi
+          
+      - name: Build benchmark
+        run: |
+          g++ -O2 -I. -I./benchmark/include -L./benchmark/build/src -std=gnu++14 -o tests/bench_movemask tests/bench_movemask.cpp -lbenchmark -lpthread -lrt
+
+      - name: Run benchmark
+        run: |
+          ./tests/bench_movemask --benchmark_format=json | tee benchmark.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'googlecpp'
+          output-file-path: benchmark.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true

--- a/tests/bench_movemask.cpp
+++ b/tests/bench_movemask.cpp
@@ -1,0 +1,205 @@
+#include <benchmark/benchmark.h>
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__)
+#include "sse2neon.h"
+#else
+#include <emmintrin.h>
+#include <xmmintrin.h>
+#endif
+#include <cstdint>
+#include <cstring>
+
+/* Simple xorshift32 PRNG for reproducible random data. */
+static uint32_t xorshift32(uint32_t *state)
+{
+    uint32_t x = *state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    return *state = x;
+}
+
+const int N_DATA = 1024;
+__m128i data_zero[N_DATA];
+__m128i data_all[N_DATA];
+__m128i data_alt[N_DATA];
+__m128i data_cmpresult[N_DATA];
+__m128i data_rand[N_DATA];
+
+void init_data()
+{
+    for (int i = 0; i < N_DATA; i++) {
+        data_zero[i] = _mm_setzero_si128();
+        data_all[i] = _mm_set1_epi8((char) 0xFF);
+        data_alt[i] = _mm_set_epi8(0x00, (char) 0x80, 0x00, (char) 0x80, 0x00,
+                                   (char) 0x80, 0x00, (char) 0x80, 0x00,
+                                   (char) 0x80, 0x00, (char) 0x80, 0x00,
+                                   (char) 0x80, 0x00, (char) 0x80);
+        data_cmpresult[i] = _mm_set_epi8(
+            (char) 0xFF, 0x00, (char) 0xFF, 0x00, (char) 0xFF, (char) 0xFF,
+            0x00, 0x00, (char) 0xFF, (char) 0xFF, (char) 0xFF, 0x00, 0x00, 0x00,
+            (char) 0xFF, (char) 0xFF);
+    }
+
+    uint32_t rng = 42;
+    for (int i = 0; i < N_DATA; i++) {
+        uint32_t r[4];
+        for (int j = 0; j < 4; j++)
+            r[j] = xorshift32(&rng);
+        data_rand[i] = _mm_loadu_si128((const __m128i *) r);
+    }
+}
+
+static void BM_Throughput_AllZero(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] +=
+            (unsigned int) _mm_movemask_epi8(data_zero[i & (N_DATA - 1)]);
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_AllZero);
+
+static void BM_Throughput_AllOnes(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] +=
+            (unsigned int) _mm_movemask_epi8(data_all[i & (N_DATA - 1)]);
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_AllOnes);
+
+static void BM_Throughput_Alternating(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] +=
+            (unsigned int) _mm_movemask_epi8(data_alt[i & (N_DATA - 1)]);
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Alternating);
+
+static void BM_Throughput_CmpResult(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] +=
+            (unsigned int) _mm_movemask_epi8(data_cmpresult[i & (N_DATA - 1)]);
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_CmpResult);
+
+static void BM_Throughput_Random(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] +=
+            (unsigned int) _mm_movemask_epi8(data_rand[i & (N_DATA - 1)]);
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Random);
+
+static void BM_Latency(benchmark::State &state)
+{
+    __m128i vec = _mm_set1_epi8((char) 0xA5);
+    for (auto _ : state) {
+        int mask = _mm_movemask_epi8(vec);
+        vec = _mm_set1_epi8((char) (mask & 0xFF));
+    }
+    benchmark::DoNotOptimize(vec);
+}
+BENCHMARK(BM_Latency);
+
+uint8_t haystack[4096];
+
+static void BM_Memchr_FoundAt2048(benchmark::State &state)
+{
+    memset(haystack, 0x42, sizeof(haystack));
+    haystack[2048] = 0xAA;
+    __m128i target = _mm_set1_epi8((char) 0xAA);
+    int len = sizeof(haystack);
+    for (auto _ : state) {
+        int found_count = 0;
+        for (int i = 0; i <= len - 16; i += 16) {
+            __m128i chunk = _mm_loadu_si128((const __m128i *) (haystack + i));
+            __m128i cmp = _mm_cmpeq_epi8(chunk, target);
+            int mask = _mm_movemask_epi8(cmp);
+            if (mask) {
+                found_count++;
+                break;
+            }
+        }
+        benchmark::DoNotOptimize(found_count);
+    }
+}
+BENCHMARK(BM_Memchr_FoundAt2048);
+
+static void BM_Memchr_NotFound(benchmark::State &state)
+{
+    memset(haystack, 0x42, sizeof(haystack));
+    __m128i target = _mm_set1_epi8((char) 0xAA);
+    int len = sizeof(haystack);
+    for (auto _ : state) {
+        int found_count = 0;
+        for (int i = 0; i <= len - 16; i += 16) {
+            __m128i chunk = _mm_loadu_si128((const __m128i *) (haystack + i));
+            __m128i cmp = _mm_cmpeq_epi8(chunk, target);
+            int mask = _mm_movemask_epi8(cmp);
+            if (mask) {
+                found_count++;
+                break;
+            }
+        }
+        benchmark::DoNotOptimize(found_count);
+    }
+}
+BENCHMARK(BM_Memchr_NotFound);
+
+static void BM_Memchr_FoundAt0(benchmark::State &state)
+{
+    memset(haystack, 0x42, sizeof(haystack));
+    haystack[0] = 0xAA;
+    __m128i target = _mm_set1_epi8((char) 0xAA);
+    int len = sizeof(haystack);
+    for (auto _ : state) {
+        int found_count = 0;
+        for (int i = 0; i <= len - 16; i += 16) {
+            __m128i chunk = _mm_loadu_si128((const __m128i *) (haystack + i));
+            __m128i cmp = _mm_cmpeq_epi8(chunk, target);
+            int mask = _mm_movemask_epi8(cmp);
+            if (mask) {
+                found_count++;
+                break;
+            }
+        }
+        benchmark::DoNotOptimize(found_count);
+    }
+}
+BENCHMARK(BM_Memchr_FoundAt0);
+
+int main(int argc, char **argv)
+{
+    init_data();
+    ::benchmark::Initialize(&argc, argv);
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+        return 1;
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+    return 0;
+}


### PR DESCRIPTION
Add Linux A32 and A64 benchmark workflows.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux A32 (armhf) and A64 benchmark workflows to build and run `_mm_movemask_epi8` microbenchmarks on Ubuntu ARM runners and fail CI on significant regressions. Uses `sse2neon` on ARM and stores results for comparison.

- **New Features**
  - A32: Cross-compiles with `arm-linux-gnueabihf-g++` (`-O2 -mfpu=neon`); enables `armhf`, installs `libc6:armhf`/`libstdc++6:armhf`/`cmake`; builds and caches `google/benchmark` v1.8.3 (LTO).
  - A64: Builds natively with `g++`; caches and builds `google/benchmark` v1.8.3 (LTO).
  - Adds `tests/bench_movemask.cpp` with throughput, latency, and memchr-style benchmarks; runs via `benchmark-action/github-action-benchmark@v1` (`tool: googlecpp`, 200% alert, comment+fail on regressions, no auto-push).

<sup>Written for commit 44cf5a37ad0d95de9c5639eea2a0efe647028ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DLTcollab/sse2neon/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



