### PR TITLE
Move non builtin clearcache before using builtin

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -4228,13 +4228,13 @@ FORCE_INLINE void _mm_clflush(void const *p)
 #if defined(__APPLE__)
     sys_icache_invalidate(_sse2neon_const_cast(void *, p),
                           SSE2NEON_CACHELINE_SIZE);
+#elif SSE2NEON_COMPILER_MSVC && SSE2NEON_INCLUDE_WINDOWS_H
+    FlushInstructionCache(GetCurrentProcess(), p, SSE2NEON_CACHELINE_SIZE);
 #elif SSE2NEON_COMPILER_GCC_COMPAT
     uintptr_t ptr = _sse2neon_reinterpret_cast(uintptr_t, p);
     __builtin___clear_cache(
         _sse2neon_reinterpret_cast(char *, ptr),
         _sse2neon_reinterpret_cast(char *, ptr) + SSE2NEON_CACHELINE_SIZE);
-#elif SSE2NEON_COMPILER_MSVC && SSE2NEON_INCLUDE_WINDOWS_H
-    FlushInstructionCache(GetCurrentProcess(), p, SSE2NEON_CACHELINE_SIZE);
 #endif
 }
 


### PR DESCRIPTION
This will cause errors when running on clang-cl targetting msvc as it will be gcc compat but `__builtin___clear_cache()` won't be available.

clang-cl is both gcc-compat and msvc. The intent is to go into the MSVC path and call `FlushInstructionCache()`, however due to being gcc-compat it will try to call `__builtin___clear_cache()` instead. This is not available on the msvc compatible frontend.

When compiling the sln with clang-cl it doesn't seem to compile anything so I've not included a test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `_mm_clflush` on `clang-cl` targeting MSVC by preferring the Windows path. Previously the GCC-compat branch ran first and called `__builtin___clear_cache`, which is unavailable in the MSVC frontend and caused build errors.

- Reorders conditionals in `sse2neon.h` to Apple -> MSVC (`FlushInstructionCache`) -> GCC-compat.
- No behavior change on Apple or non-MSVC GCC/Clang targets.
- MSVC path still requires `SSE2NEON_INCLUDE_WINDOWS_H`; otherwise behavior remains unchanged.

<sup>Written for commit 9e0dbf7fc99ab4fab6531042b29400b6dae9430c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DLTcollab/sse2neon/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

