### PR TITLE
Add opt-in SVE2 fast path for _SIDD_CMP_EQUAL_ANY

### DIFF
--- a/.github/workflows/benchmark-linux-a64.yml
+++ b/.github/workflows/benchmark-linux-a64.yml
@@ -56,3 +56,92 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true
+
+  # NEON against SVE2 for the one relation SVE2 MATCH computes directly.
+  # Both numbers come from the same source built twice on the same runner, so
+  # the comparison is not across machines or across thermal states.
+  cmpistr-sve2:
+    name: Compare NEON and SVE2 for EQUAL_ANY on Linux A64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          # scipy and numpy are what benchmark/tools/compare.py runs its
+          # U-test with; without them it refuses to report.
+          sudo apt-get install -y g++ cmake python3-numpy python3-scipy
+
+      - name: Require SVE2 on the runner
+        run: |
+          grep -m1 '^Features' /proc/cpuinfo
+          if ! grep -qw sve2 /proc/cpuinfo; then
+            echo "ERROR: runner reports no SVE2; both builds would be NEON"
+            exit 1
+          fi
+
+      - name: Cache Benchmark library
+        uses: actions/cache@v4
+        with:
+          path: benchmark
+          key: ${{ runner.os }}-googlebenchmark-a64-v1.8.3
+
+      - name: Build Google Benchmark
+        run: |
+          if [ ! -d "benchmark/build" ]; then
+            git clone --branch v1.8.3 --depth 1 https://github.com/google/benchmark.git
+            cd benchmark
+            cmake -E make_directory "build"
+            cmake -E chdir "build" cmake -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=OFF -DBENCHMARK_ENABLE_LTO=true ..
+            cmake --build "build" --config Release
+          fi
+
+      # clean between the two, because the flags change and the executable's
+      # timestamp does not.
+      - name: Benchmark the NEON path
+        env:
+          LD_LIBRARY_PATH: ./benchmark/build/src
+        run: |
+          make clean
+          make bench-cmpistr CXX=g++ \
+            BENCHMARK_CXXFLAGS="-I./benchmark/include" \
+            BENCHMARK_LDFLAGS="-L./benchmark/build/src -lbenchmark -lpthread -lrt" \
+            BENCH_ARGS="--benchmark_format=json --benchmark_out=$PWD/neon.json"
+
+      - name: Benchmark the SVE2 path
+        env:
+          LD_LIBRARY_PATH: ./benchmark/build/src
+        run: |
+          make clean
+          make bench-cmpistr SVE=1 FEATURE=sve2 CXX=g++ \
+            BENCHMARK_CXXFLAGS="-I./benchmark/include" \
+            BENCHMARK_LDFLAGS="-L./benchmark/build/src -lbenchmark -lpthread -lrt" \
+            BENCH_ARGS="--benchmark_format=json --benchmark_out=$PWD/sve2.json"
+          count=$(objdump -d tests/bench_cmpistr | grep -cE '\bmatch[[:space:]]+p[0-9]' || true)
+          echo "MATCH instructions in tests/bench_cmpistr: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: no MATCH instruction; this run measured the NEON path twice"
+            exit 1
+          fi
+
+      - name: Report the comparison
+        run: |
+          python3 benchmark/tools/compare.py --no-color benchmarks neon.json sve2.json | tee compare.txt
+          {
+            echo '### `_SIDD_CMP_EQUAL_ANY`: NEON vs SVE2'
+            echo
+            echo 'Same source, same runner, built twice. Negative means SVE2 is faster.'
+            echo
+            echo '```'
+            cat compare.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark JSON
+        uses: actions/upload-artifact@v5
+        with:
+          name: cmpistr-neon-vs-sve2
+          path: |
+            neon.json
+            sve2.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,69 @@ jobs:
             make FEATURE=${{ matrix.feature }} check
           fi
 
+  # SVE2 on the Neoverse N2 behind GitHub's arm64 runners. The paths guarded by
+  # SSE2NEON_ENABLE_SVE are compiled by nothing above this job, so without it
+  # the whole opt-in feature is untested.
+  host-arm-sve2:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        cxx_compiler: [g++, clang++-18]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: install clang
+        if: contains(matrix.cxx_compiler, 'clang')
+        run: |
+          # clang-18 is in 'universe' repository on Ubuntu 24.04
+          sudo add-apt-repository -y -n universe
+          sudo apt-get -o Acquire::Retries=5 update -q -y
+          sudo apt-get -o Acquire::Retries=5 install -q -y --no-install-recommends "${CXX_COMPILER/clang++/clang}"
+        env:
+          CXX_COMPILER: ${{ matrix.cxx_compiler }}
+      # A runner without SVE2 builds the NEON paths and passes, which is the
+      # one result this job must never report as success.
+      - name: require SVE2 on the runner
+        run: |
+          grep -m1 '^Features' /proc/cpuinfo
+          if ! grep -qw sve2 /proc/cpuinfo; then
+            echo "ERROR: runner reports no SVE2; this job would test the NEON paths instead"
+            exit 1
+          fi
+      - name: build and test
+        env:
+          CXX: ${{ matrix.cxx_compiler }}
+        run: make SVE=1 FEATURE=sve2 check
+      # MATCH writes a predicate register, which no NEON encoding does, so its
+      # presence separates a real SVE2 build from one where the macro was
+      # defined and the paths gated out anyway.
+      - name: require MATCH in the test binary
+        run: |
+          count=$(objdump -d tests/main | grep -cE '\bmatch[[:space:]]+p[0-9]' || true)
+          echo "MATCH instructions in tests/main: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: no MATCH instruction; the SVE2 path was not compiled in"
+            exit 1
+          fi
+
+  # The vector-length sweep. GitHub's arm64 runners are 128-bit, so QEMU is the
+  # only way to run this code at 256 and 512 bits, which is what the sizeless
+  # SVE types in sse2neon.h claim to support. EXEC_WRAPPER is set only when
+  # CROSS_COMPILE is, so this cross-compiles from x86 rather than running on the
+  # arm runner.
+  host-arm-sve2-vl:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: install cross toolchain and QEMU
+        run: |
+          sudo apt-get -o Acquire::Retries=5 update -q -y
+          sudo apt-get -o Acquire::Retries=5 install -q -y --no-install-recommends \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
+      - name: run the suite at every vector length
+        run: make CROSS_COMPILE=aarch64-linux-gnu- check-sve
+
   # ARMv7 requires QEMU emulation - minimize job count
   host-arm-emulated:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ ifdef ARCH_CFLAGS_IS_SET
 endif
 
 COMMA := ,
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
 
 FEATURE ?=
 ifneq ($(FEATURE),)
@@ -351,14 +353,21 @@ FUZZ_CXXFLAGS = -g -O1 -fsanitize=fuzzer,address,undefined -fno-omit-frame-point
 # Enable crypto extensions for AES and CLMUL testing on AArch64
 FUZZ_ARCH_FLAGS := $(ARCH_CFLAGS)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64))
-FUZZ_ARCH_FLAGS := -march=armv8-a+fp+simd+crypto+crc
-# The -march above replaces ARCH_CFLAGS, so FEATURE has to be folded back in
-# here; without it SVE=1 FEATURE=sve2 would fuzz the NEON paths only.
+# The -march below replaces ARCH_CFLAGS, so FEATURE has to be folded back in
+# here; without it SVE=1 FEATURE=sve2 would fuzz the NEON paths only. Anything
+# the fuzzer already asks for is filtered out first, so FEATURE=crypto+crc does
+# not append a second +crypto+crc.
+FUZZ_BASE_FEATURES := fp simd crypto crc
+FUZZ_EXTRA_FEATURES :=
 ifneq ($(FEATURE),)
 ifneq ($(FEATURE),none)
-FUZZ_ARCH_FLAGS := $(FUZZ_ARCH_FLAGS)+$(subst $(COMMA),+,$(FEATURE))
+FUZZ_EXTRA_FEATURES := $(filter-out $(FUZZ_BASE_FEATURES), \
+    $(subst +, ,$(subst $(COMMA), ,$(FEATURE))))
 endif
 endif
+# $(addprefix) yields space-separated words, which would reach the compiler as
+# separate argv tokens; collapse them back into one +a+b string.
+FUZZ_ARCH_FLAGS := -march=armv8-a+fp+simd+crypto+crc$(subst $(SPACE),,$(addprefix +,$(FUZZ_EXTRA_FEATURES)))
 endif
 FUZZ_CXXFLAGS += -Wall -Wno-unused-function -I. $(FUZZ_ARCH_FLAGS) -std=gnu++14 $(SVE_FLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ ifdef ARCH_CFLAGS_IS_SET
     endif
 endif
 
+COMMA := ,
+
 FEATURE ?=
 ifneq ($(FEATURE),)
 ifneq ($(FEATURE),none)
-COMMA:= ,
 override ARCH_CFLAGS := $(ARCH_CFLAGS)+$(subst $(COMMA),+,$(FEATURE))
 endif
 endif
@@ -66,6 +67,19 @@ SANITIZE_FLAGS = -fsanitize=$(SANITIZE) -fno-omit-frame-pointer
 SANITIZE_FLAGS += -fwrapv
 else
 SANITIZE_FLAGS =
+endif
+
+# Opt-in SVE2 code paths: SVE=1 defines SSE2NEON_ENABLE_SVE.
+# Pair with FEATURE=sve2 so the compiler also reports __ARM_FEATURE_SVE2;
+# without it the header silently keeps the NEON paths.
+SVE ?=
+SVE_FLAGS =
+ifeq ($(SVE),1)
+SVE_FLAGS = -DSSE2NEON_ENABLE_SVE=1
+else ifneq ($(SVE),)
+ifneq ($(SVE),0)
+$(error Unsupported SVE value '$(SVE)'; use SVE=1 to enable, SVE=0 or unset to disable)
+endif
 endif
 
 # Strict aliasing checking: STRICT_ALIASING=1 to enable
@@ -94,7 +108,7 @@ else
 EXTRA_WARNINGS_FLAGS =
 endif
 
-CXXFLAGS += -Wall -Wcast-qual -Wold-style-cast -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14 $(SANITIZE_FLAGS) $(STRICT_ALIASING_FLAGS) $(EXTRA_WARNINGS_FLAGS)
+CXXFLAGS += -Wall -Wcast-qual -Wold-style-cast -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14 $(SANITIZE_FLAGS) $(STRICT_ALIASING_FLAGS) $(EXTRA_WARNINGS_FLAGS) $(SVE_FLAGS)
 LDFLAGS  += -lm $(SANITIZE_FLAGS)
 OBJS = \
     tests/binding.o \
@@ -147,25 +161,25 @@ $(AES_EXEC): $(AES_OBJS)
 
 ieee754: $(IEEE754_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $^
 
 nan: $(NAN_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $^
 
 aes: $(AES_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $^
 
 check: tests/main $(IEEE754_EXEC) $(NAN_EXEC) $(AES_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) tests/main
 	$(EXEC_WRAPPER) $(IEEE754_EXEC)
@@ -189,30 +203,60 @@ indent:
 # Convenience target for running only main tests (skip IEEE-754)
 check-main: $(EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $(EXEC)
 
 # Convenience target for running only IEEE-754 edge case tests (skip main)
 check-ieee754: $(IEEE754_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $(IEEE754_EXEC)
 
 # Convenience target for running only NaN propagation tests (skip main)
 check-nan: $(NAN_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $(NAN_EXEC)
 
 # Convenience target for running only AES validation tests (skip main)
 check-aes: $(AES_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $(AES_EXEC)
+
+# Convenience target for the opt-in SVE2 code paths.
+#
+# __m128 is a fixed 128-bit contract, so the SVE paths use fixed-width
+# predicates (svptrue_pat_b8(SV_VL16) and friends) rather than VLA loops.
+# They are written with sizeless SVE types only and so must stay correct at
+# every hardware vector length -- this target proves that by re-running the
+# whole suite at each length in SVE_VECTOR_LENGTHS (bytes) under QEMU.
+#
+# Usage: make CROSS_COMPILE=aarch64-linux-gnu- check-sve
+SVE_VECTOR_LENGTHS ?= 16 32 64
+
+check-sve:
+ifneq ($(processor),$(filter $(processor),aarch64 arm64))
+	@echo "ERROR: check-sve requires an AArch64 target, but the target is '$(processor)'"
+	@echo "Use: make CROSS_COMPILE=aarch64-linux-gnu- check-sve"
+	@exit 1
+else ifeq ($(EXEC_WRAPPER),)
+	@echo "== SVE2 build, native (vector length is whatever the CPU provides) =="
+	$(MAKE) clean
+	$(MAKE) SVE=1 FEATURE=sve2 check
+else
+	@for vl in $(SVE_VECTOR_LENGTHS); do \
+	    echo "== SVE2 build, hardware vector length $$vl bytes =="; \
+	    $(MAKE) clean > /dev/null || exit 1; \
+	    $(MAKE) SVE=1 FEATURE=sve2 \
+	        EXEC_WRAPPER="$(EXEC_WRAPPER) -cpu max,sve-default-vector-length=$$vl" \
+	        check || exit 1; \
+	done
+endif
 
 # Convenience target for running tests with UBSan
 check-ubsan: clean
@@ -283,7 +327,7 @@ check-differential: $(DIFFERENTIAL_EXEC)
 		exit 1; \
 	fi
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $(DIFFERENTIAL_EXEC) --verify $(GOLDEN_DIR)
 
@@ -308,8 +352,15 @@ FUZZ_CXXFLAGS = -g -O1 -fsanitize=fuzzer,address,undefined -fno-omit-frame-point
 FUZZ_ARCH_FLAGS := $(ARCH_CFLAGS)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64))
 FUZZ_ARCH_FLAGS := -march=armv8-a+fp+simd+crypto+crc
+# The -march above replaces ARCH_CFLAGS, so FEATURE has to be folded back in
+# here; without it SVE=1 FEATURE=sve2 would fuzz the NEON paths only.
+ifneq ($(FEATURE),)
+ifneq ($(FEATURE),none)
+FUZZ_ARCH_FLAGS := $(FUZZ_ARCH_FLAGS)+$(subst $(COMMA),+,$(FEATURE))
 endif
-FUZZ_CXXFLAGS += -Wall -Wno-unused-function -I. $(FUZZ_ARCH_FLAGS) -std=gnu++14
+endif
+endif
+FUZZ_CXXFLAGS += -Wall -Wno-unused-function -I. $(FUZZ_ARCH_FLAGS) -std=gnu++14 $(SVE_FLAGS)
 
 # On macOS, prefer Homebrew LLVM if available (has libFuzzer built-in)
 UNAME_S := $(shell uname -s)
@@ -377,13 +428,13 @@ $(BENCH_MOVEMASK_EXEC): $(BENCH_MOVEMASK_SRC) sse2neon.h
 
 bench-movemask: $(BENCH_MOVEMASK_EXEC)
 ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
-	$(CC) $(ARCH_CFLAGS) -c sse2neon.h
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
 endif
 	$(EXEC_WRAPPER) $^ $(BENCH_ARGS)
 
 bench: bench-movemask
 
-.PHONY: clean check check-main check-ieee754 check-nan check-aes check-ubsan check-asan check-strict-aliasing check-uninit check-macros check-differential generate-golden coverage-report indent ieee754 nan aes fuzz fuzz-verbose fuzz-clean bench bench-movemask
+.PHONY: clean check check-main check-ieee754 check-nan check-aes check-sve check-ubsan check-asan check-strict-aliasing check-uninit check-macros check-differential generate-golden coverage-report indent ieee754 nan aes fuzz fuzz-verbose fuzz-clean bench bench-movemask
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps) sse2neon.h.gch
 	$(RM) $(IEEE754_OBJS) $(IEEE754_EXEC) $(ieee754_deps)

--- a/Makefile
+++ b/Makefile
@@ -441,9 +441,25 @@ ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
 endif
 	$(EXEC_WRAPPER) $^ $(BENCH_ARGS)
 
-bench: bench-movemask
+# EQUAL_ANY string-comparison benchmark
+#
+# Built from the same source with and without SVE=1 to compare the two paths;
+# see the header comment in tests/bench_cmpistr.cpp.
+BENCH_CMPISTR_SRC = tests/bench_cmpistr.cpp
+BENCH_CMPISTR_EXEC = tests/bench_cmpistr
 
-.PHONY: clean check check-main check-ieee754 check-nan check-aes check-sve check-ubsan check-asan check-strict-aliasing check-uninit check-macros check-differential generate-golden coverage-report indent ieee754 nan aes fuzz fuzz-verbose fuzz-clean bench bench-movemask
+$(BENCH_CMPISTR_EXEC): $(BENCH_CMPISTR_SRC) sse2neon.h
+	$(CXX) -O2 $(ARCH_CFLAGS) $(CXXFLAGS) $(BENCHMARK_CXXFLAGS) -I. -std=gnu++14 $(LDFLAGS) -o $@ $< $(BENCHMARK_LDFLAGS)
+
+bench-cmpistr: $(BENCH_CMPISTR_EXEC)
+ifeq ($(processor),$(filter $(processor),aarch64 arm64 arm armv7l))
+	$(CC) $(ARCH_CFLAGS) $(SVE_FLAGS) -c sse2neon.h
+endif
+	$(EXEC_WRAPPER) $^ $(BENCH_ARGS)
+
+bench: bench-movemask bench-cmpistr
+
+.PHONY: clean check check-main check-ieee754 check-nan check-aes check-sve check-ubsan check-asan check-strict-aliasing check-uninit check-macros check-differential generate-golden coverage-report indent ieee754 nan aes fuzz fuzz-verbose fuzz-clean bench bench-movemask bench-cmpistr
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps) sse2neon.h.gch
 	$(RM) $(IEEE754_OBJS) $(IEEE754_EXEC) $(ieee754_deps)
@@ -452,6 +468,7 @@ clean:
 	$(RM) $(DIFFERENTIAL_OBJS) $(DIFFERENTIAL_EXEC) $(differential_deps)
 	$(RM) $(FUZZ_EXEC)
 	$(RM) $(BENCH_MOVEMASK_EXEC)
+	$(RM) $(BENCH_CMPISTR_EXEC)
 
 -include $(deps)
 -include $(ieee754_deps)

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -222,6 +222,30 @@
 #define SSE2NEON_INCLUDE_WINDOWS_H (0)
 #endif
 
+/* SSE2NEON_ENABLE_SVE
+ * Affects: _mm_cmpistr* / _mm_cmpestr* using _SIDD_CMP_EQUAL_ANY
+ *
+ * Opt-in Arm SVE2 code paths. Disabled by default: the NEON implementations
+ * stay the default on every target, and setting this on a build without SVE2
+ * silently keeps them, so the flag is safe to define globally.
+ *
+ * Default (0): NEON only
+ * Enabled (1): use SVE2 where it is a measured win, and only where the
+ *              compiler also reports __ARM_FEATURE_SVE2, as -march=armv8-a+sve2
+ *              does
+ *
+ * Fixed vector length: the __m128 family is a 128-bit contract, so these
+ * paths use fixed-width predicates (svptrue_pat_b8(SV_VL16) and friends)
+ * instead of vector-length-agnostic loops. They are written with sizeless SVE
+ * types only, so they stay correct at any hardware vector length; a header
+ * cannot impose -msve-vector-bits (a global ABI flag) on its users, and that
+ * option would additionally make the code undefined on any machine whose
+ * vector length is not exactly the value it names.
+ */
+#ifndef SSE2NEON_ENABLE_SVE
+#define SSE2NEON_ENABLE_SVE (0)
+#endif
+
 /* Consolidated Platform Detection
  *
  * These macros simplify platform-specific code throughout the header by
@@ -628,6 +652,17 @@ FORCE_INLINE void _sse2neon_smp_mb(void)
 #endif
 #else
 #define SSE2NEON_HAS_ACLE 0
+#endif
+
+/* Opt-in SVE2 support. Requires SSE2NEON_ENABLE_SVE=1 from the user, an
+ * AArch64 target, and a compiler reporting __ARM_FEATURE_SVE2. When any of
+ * those is missing the NEON paths are used unchanged.
+ */
+#if SSE2NEON_ENABLE_SVE && SSE2NEON_ARCH_AARCH64 && defined(__ARM_FEATURE_SVE2)
+#include <arm_sve.h>
+#define SSE2NEON_HAS_SVE2 1
+#else
+#define SSE2NEON_HAS_SVE2 0
 #endif
 
 /* Apple Silicon cache lines are double of what is commonly used by Intel, AMD
@@ -9643,6 +9678,92 @@ static const uint8_t ALIGN_STRUCT(16) _sse2neon_cmpestr_mask8b[16] = {
             SSE2NEON_CAT(SSE2NEON_NUMBER_OF_LANES_, type), la, lb, mtx);       \
     }
 
+#if SSE2NEON_HAS_SVE2
+/* SVE2 fast path for _SIDD_CMP_EQUAL_ANY.
+ *
+ * Result bit j is set when b[j] equals any of a[0..la), for j < lb. The NEON
+ * path builds a 16x16 comparison matrix and reduces it row by row; SVE2 MATCH
+ * computes the whole relation in one instruction, because it compares each
+ * element of its first operand against every element in the corresponding
+ * 128-bit segment of its second.
+ *
+ * MATCH always scans that full segment, so a's lanes at and beyond la must
+ * not be able to produce a hit. Filling them with a[0] is safe: a[0] is
+ * itself a valid element, so any match it creates is one MATCH would have
+ * reported anyway. la == 0 leaves no element to replicate and is handled
+ * before the comparison.
+ *
+ * MATCH is defined for 8- and 16-bit elements only, which is exactly the byte
+ * and word forms required here.
+ */
+static uint16_t _sse2neon_cmp_byte_equal_any(__m128i a,
+                                             int la,
+                                             __m128i b,
+                                             int lb)
+{
+    if (la == 0)
+        return 0;
+
+    /* __m128i is a NEON type; move it into an SVE register through memory.
+     * The NEON-SVE bridge (svset_neonq) would avoid the round trip but is not
+     * available on every supported compiler.
+     */
+    uint8_t abuf[16], bbuf[16];
+    vst1q_u8(abuf, vreinterpretq_u8_m128i(a));
+    vst1q_u8(bbuf, vreinterpretq_u8_m128i(b));
+
+    svbool_t pg = svptrue_pat_b8(SV_VL16);
+    svuint8_t za = svld1_u8(pg, abuf);
+    svuint8_t zb = svld1_u8(pg, bbuf);
+
+    svbool_t pa = svwhilelt_b8_s32(0, la);
+    svuint8_t za_valid = svsel_u8(pa, za, svdup_lane_u8(za, 0));
+
+    /* The governing predicate clears result lanes j >= lb. */
+    svbool_t pb = svwhilelt_b8_s32(0, lb);
+    svbool_t match = svmatch_u8(pb, zb, za_valid);
+
+    /* Predicate -> 16-bit mask. svaddv_u8 returns uint8_t, so weight lane j
+     * by 1 << (j & 7) and reduce the two halves separately.
+     */
+    svbool_t pg_lo = svptrue_pat_b8(SV_VL8);
+    svbool_t pg_hi = svbic_b_z(pg, pg, pg_lo);
+    svuint8_t weight =
+        svlsl_u8_x(pg, svdup_n_u8(1), svand_n_u8_x(pg, svindex_u8(0, 1), 7));
+    svuint8_t bits = svsel_u8(match, weight, svdup_n_u8(0));
+
+    return _sse2neon_static_cast(
+        uint16_t, svaddv_u8(pg_lo, bits) | (svaddv_u8(pg_hi, bits) << 8));
+}
+
+static uint16_t _sse2neon_cmp_word_equal_any(__m128i a,
+                                             int la,
+                                             __m128i b,
+                                             int lb)
+{
+    if (la == 0)
+        return 0;
+
+    uint16_t abuf[8], bbuf[8];
+    vst1q_u16(abuf, vreinterpretq_u16_m128i(a));
+    vst1q_u16(bbuf, vreinterpretq_u16_m128i(b));
+
+    svbool_t pg = svptrue_pat_b16(SV_VL8);
+    svuint16_t za = svld1_u16(pg, abuf);
+    svuint16_t zb = svld1_u16(pg, bbuf);
+
+    svbool_t pa = svwhilelt_b16_s32(0, la);
+    svuint16_t za_valid = svsel_u16(pa, za, svdup_lane_u16(za, 0));
+
+    svbool_t pb = svwhilelt_b16_s32(0, lb);
+    svbool_t match = svmatch_u16(pb, zb, za_valid);
+
+    /* Eight lanes weigh at most 0xff in total, so one reduction suffices. */
+    svuint16_t weight = svlsl_u16_x(pg, svdup_n_u16(1), svindex_u16(0, 1));
+    return _sse2neon_static_cast(
+        uint16_t, svaddv_u16(pg, svsel_u16(match, weight, svdup_n_u16(0))));
+}
+#else
 static uint16_t _sse2neon_aggregate_equal_any_8x16(int la,
                                                    int lb,
                                                    __m128i mtx[16])
@@ -9734,6 +9855,7 @@ static uint16_t _sse2neon_aggregate_equal_any_16x8(int la,
 /* clang-format on */
 
 SSE2NEON_GENERATE_CMP_EQUAL_ANY(SSE2NEON_CMP_EQUAL_ANY_)
+#endif /* SSE2NEON_HAS_SVE2 */
 
 static uint16_t _sse2neon_aggregate_ranges_16x8(int la, int lb, __m128i mtx[16])
 {

--- a/tests/bench_cmpistr.cpp
+++ b/tests/bench_cmpistr.cpp
@@ -1,0 +1,254 @@
+/**
+ * Benchmark for the _SIDD_CMP_EQUAL_ANY string-comparison intrinsics.
+ *
+ * Measures three dimensions:
+ *   1. Throughput: independent calls (pipeline utilization)
+ *   2. Latency: dependent chain (true instruction latency)
+ *   3. In-context: strcspn-like delimiter scan (realistic usage)
+ *
+ * EQUAL_ANY is the relation SVE2 MATCH computes directly, so this is the
+ * benchmark that answers whether SSE2NEON_ENABLE_SVE is worth defining.
+ * Build the same source twice and compare:
+ *
+ *   make bench-cmpistr                                     # NEON path
+ *   make bench-cmpistr SVE=1 FEATURE=sve2                  # SVE2 path
+ *   make bench-cmpistr CROSS_COMPILE=aarch64-linux-gnu-    # AArch64 + QEMU
+ *
+ * The set operand is null-terminated below 16 bytes, because that is what a
+ * delimiter set looks like in practice and it is also the case the SVE2 path
+ * has to pad: MATCH scans the whole 128-bit segment, so lanes at and beyond
+ * la are filled with a[0].
+ */
+
+#include <benchmark/benchmark.h>
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__)
+#include "sse2neon.h"
+#else
+#include <nmmintrin.h>
+#endif
+
+#include <cstdint>
+#include <cstring>
+
+/* Simple xorshift32 PRNG for reproducible random data. */
+static uint32_t xorshift32(uint32_t *state)
+{
+    uint32_t x = *state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    return *state = x;
+}
+
+const int BYTE_MODE = _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY;
+const int WORD_MODE = _SIDD_UWORD_OPS | _SIDD_CMP_EQUAL_ANY;
+
+const int N_DATA = 1024;
+
+/* The needle: a five-character delimiter set, null-terminated so the implicit
+ * length is 5 rather than 16. */
+__m128i set_byte;
+__m128i set_word;
+
+/* Haystacks, by where the first set member falls: nowhere, lane 15, lane 0.
+ * The three differ in how much of the segment the aggregation has to walk. */
+__m128i data_nomatch[N_DATA];
+__m128i data_late[N_DATA];
+__m128i data_early[N_DATA];
+__m128i data_rand[N_DATA];
+
+void init_data()
+{
+    volatile char dyn_zero = 0;  // Prevent constant-folding at -O3
+
+    const char delims[16] = {' ', '\t', '\n', ',', ';', 0, 0, 0,
+                             0,   0,    0,    0,   0,   0, 0, 0};
+    set_byte = _mm_loadu_si128(reinterpret_cast<const __m128i *>(delims));
+
+    const int16_t wdelims[8] = {' ', '\t', '\n', ',', ';', 0, 0, 0};
+    set_word = _mm_loadu_si128(reinterpret_cast<const __m128i *>(wdelims));
+
+    uint32_t rng = 42;
+    for (int i = 0; i < N_DATA; i++) {
+        uint32_t r[4];
+        for (int j = 0; j < 4; j++)
+            r[j] = xorshift32(&rng);
+        data_rand[i] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(r));
+
+        /* 'x' is in neither set, so these are built from it and then seeded
+         * with one delimiter. dyn_zero keeps them off the constant path. */
+        char none[16], late[16], early[16];
+        for (int j = 0; j < 16; j++)
+            none[j] = late[j] = early[j] = static_cast<char>(dyn_zero | 'x');
+        late[15] = ',';
+        early[0] = ',';
+
+        data_nomatch[i] =
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(none));
+        data_late[i] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(late));
+        data_early[i] =
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(early));
+    }
+}
+
+static void BM_Throughput_Index_NoMatch(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] += static_cast<unsigned int>(
+            _mm_cmpistri(set_byte, data_nomatch[i & (N_DATA - 1)], BYTE_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Index_NoMatch);
+
+static void BM_Throughput_Index_MatchLate(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] += static_cast<unsigned int>(
+            _mm_cmpistri(set_byte, data_late[i & (N_DATA - 1)], BYTE_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Index_MatchLate);
+
+static void BM_Throughput_Index_MatchEarly(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] += static_cast<unsigned int>(
+            _mm_cmpistri(set_byte, data_early[i & (N_DATA - 1)], BYTE_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Index_MatchEarly);
+
+static void BM_Throughput_Index_Random(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] += static_cast<unsigned int>(
+            _mm_cmpistri(set_byte, data_rand[i & (N_DATA - 1)], BYTE_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Index_Random);
+
+static void BM_Throughput_Mask_Random(benchmark::State &state)
+{
+    __m128i acc = _mm_setzero_si128();
+    int i = 0;
+    for (auto _ : state) {
+        acc = _mm_xor_si128(
+            acc,
+            _mm_cmpistrm(set_byte, data_rand[i & (N_DATA - 1)], BYTE_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc);
+}
+BENCHMARK(BM_Throughput_Mask_Random);
+
+/* The word form takes the other MATCH element size and half the lanes. */
+static void BM_Throughput_Index_Word_Random(benchmark::State &state)
+{
+    unsigned int acc[4] = {0};
+    int i = 0;
+    for (auto _ : state) {
+        acc[i & 3] += static_cast<unsigned int>(
+            _mm_cmpistri(set_word, data_rand[i & (N_DATA - 1)], WORD_MODE));
+        i++;
+    }
+    benchmark::DoNotOptimize(acc[0] + acc[1] + acc[2] + acc[3]);
+}
+BENCHMARK(BM_Throughput_Index_Word_Random);
+
+/* Each call consumes the previous result, so these measure latency rather
+ * than how many the pipeline keeps in flight. */
+static void BM_Latency_Index(benchmark::State &state)
+{
+    __m128i vec = data_rand[0];
+    for (auto _ : state) {
+        int index = _mm_cmpistri(set_byte, vec, BYTE_MODE);
+        /* Folded back in so the next call cannot start before this one
+         * retires, which is the whole point of the chain. */
+        vec = _mm_xor_si128(vec, _mm_set1_epi8(static_cast<char>(index)));
+    }
+    benchmark::DoNotOptimize(vec);
+}
+BENCHMARK(BM_Latency_Index);
+
+static void BM_Latency_Mask(benchmark::State &state)
+{
+    __m128i vec = data_rand[0];
+    for (auto _ : state) {
+        vec = _mm_cmpistrm(set_byte, vec, BYTE_MODE);
+    }
+    benchmark::DoNotOptimize(vec);
+}
+BENCHMARK(BM_Latency_Mask);
+
+char text[4096];
+
+/* strcspn: walk until a character from the set turns up. This is the loop
+ * EQUAL_ANY exists for, and the one a tokenizer actually runs. */
+static int strcspn_sse42(const char *buf, int len, __m128i set)
+{
+    for (int i = 0; i <= len - 16; i += 16) {
+        __m128i chunk =
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(buf + i));
+        int index = _mm_cmpistri(set, chunk, BYTE_MODE);
+        if (index != 16)
+            return i + index;
+    }
+    return len;
+}
+
+static void BM_Strcspn_FoundAt2048(benchmark::State &state)
+{
+    memset(text, 'x', sizeof(text));
+    text[2048] = ',';
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(strcspn_sse42(text, sizeof(text), set_byte));
+    }
+}
+BENCHMARK(BM_Strcspn_FoundAt2048);
+
+static void BM_Strcspn_NotFound(benchmark::State &state)
+{
+    memset(text, 'x', sizeof(text));
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(strcspn_sse42(text, sizeof(text), set_byte));
+    }
+}
+BENCHMARK(BM_Strcspn_NotFound);
+
+static void BM_Strcspn_FoundAt0(benchmark::State &state)
+{
+    memset(text, 'x', sizeof(text));
+    text[0] = ',';
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(strcspn_sse42(text, sizeof(text), set_byte));
+    }
+}
+BENCHMARK(BM_Strcspn_FoundAt0);
+
+int main(int argc, char **argv)
+{
+    init_data();
+    ::benchmark::Initialize(&argc, argv);
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+        return 1;
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+    return 0;
+}


### PR DESCRIPTION
Partially addresses #537.

SVE2 `MATCH` (FEAT_SVE2) compares each element of its first operand against
every element in the corresponding 128-bit segment of its second, setting the
destination predicate accordingly. That is exactly the `PCMPISTRM`/`PCMPESTRM`
EQUAL_ANY relation, which the current NEON path computes by materialising a
16x16 comparison matrix and reducing it row by row.

## Change

`sse2neon.h`, 122 insertions, no deletions:

- `SSE2NEON_ENABLE_SVE`, default 0, documented alongside the existing
  `SSE2NEON_PRECISE_*` tunables.
- `SSE2NEON_HAS_SVE2`, which additionally requires `SSE2NEON_ARCH_AARCH64` and
  `__ARM_FEATURE_SVE2`. When any condition fails the NEON path is used, so the
  tunable is safe to define unconditionally.
- SVE2 implementations of `_sse2neon_cmp_byte_equal_any` and
  `_sse2neon_cmp_word_equal_any`. Their signatures and their slots in
  `_sse2neon_cmpfunc_table` are unchanged, so `SSE2NEON_COMP_AGG` and all 14
  public `_mm_cmpistr*`/`_mm_cmpestr*` entry points are untouched.

`Makefile`, 48 insertions, 12 deletions: an `SVE=1` flag following the shape of
the existing `SANITIZE` and `STRICT_ALIASING` blocks, and a `check-sve` target.

`MATCH` is defined for 8- and 16-bit elements only, which covers exactly the
byte and word forms required here.

## Length handling

`MATCH` always scans the full 128-bit segment of its second operand, so lanes
of `a` at and beyond `la` must not contribute. They are filled with `a[0]`:

    za_valid[i] = a[i]  for i < la
                = a[0]  for la <= i < 16

so `MATCH(b[j])` is `(exists i < la: b[j] == a[i]) or (b[j] == a[0])`. Since
`la >= 1` at that point, `a[0]` lies within the valid range and the second
disjunct is subsumed by the first. `la == 0` returns 0 before the comparison,
as the NEON path does.

`SSE2NEON_CMPESTRX_LEN_PAIR` takes the absolute value and clamps to `bound`,
so `la` and `lb` reach these functions in `[0, 16]` for bytes and `[0, 8]` for
words. No further clamping is required.

## Vector length

`__m128` is a fixed 128-bit contract, so the code uses fixed-width predicates
(`svptrue_pat_b8(SV_VL16)` and friends) rather than vector-length-agnostic
loops. It is nonetheless written with sizeless SVE types only and remains
correct at any hardware vector length.

`-msve-vector-bits` is deliberately not used. It is a global ABI option that a
header cannot impose on its users, and it renders the code undefined on any
machine whose vector length differs from the value it names.

The NEON-to-SVE move goes through memory because `svset_neonq`
(`arm_neon_sve_bridge.h`) requires GCC 14 or Clang 16, above this project's
stated minimum. Using the bridge where available is a possible follow-up.

## Instruction counts

aarch64-linux-gnu-gcc 13.3, `-O2`:

| | NEON | SVE2 |
|---|---|---|
| `_sse2neon_cmp_byte_equal_any` | 150 | 30 |
| `_sse2neon_cmp_word_equal_any` | 78 | 24 |

## Measurements

Two SoC generations, six microarchitectures, both with SVE2 at 128-bit vectors.
The NEON and SVE2 paths are linked into one binary as two translation units and
measured back to back, so they see identical thermal and frequency conditions.
Per call, 16-byte vectors, minimum of 15 trials of 200 repetitions, pinned with
`taskset`. NEON -> SVE2:

Google Tensor G3, Android 15:

| | Cortex-X3 2.9 GHz | Cortex-A715 2.4 GHz | Cortex-A510 1.7 GHz |
|---|---|---|---|
| `_mm_cmpistri` byte | 11.43 -> 3.73 ns (3.07x) | 22.98 -> 6.75 ns (3.40x) | 71.93 -> 49.30 ns (1.46x) |
| `_mm_cmpistrm` byte | 11.67 -> 3.94 ns (2.96x) | 23.39 -> 7.41 ns (3.16x) | 76.65 -> 55.23 ns (1.39x) |
| `_mm_cmpistri` word | 5.57 -> 3.11 ns (1.79x) | 11.45 -> 5.87 ns (1.95x) | 48.74 -> 45.72 ns (1.07x) |

Google Tensor G5, Android 16:

| | Cortex-X4 3.8 GHz | Cortex-A725 3.1 GHz | Cortex-A520 2.2 GHz |
|---|---|---|---|
| `_mm_cmpistri` byte | 9.70 -> 3.09 ns (3.14x) | 17.87 -> 4.64 ns (3.85x) | 57.32 -> 37.44 ns (1.53x) |
| `_mm_cmpistrm` byte | 10.07 -> 3.28 ns (3.07x) | 18.12 -> 4.86 ns (3.73x) | 60.93 -> 41.47 ns (1.47x) |
| `_mm_cmpistri` word | 5.00 -> 2.57 ns (1.94x) | 8.82 -> 4.10 ns (2.15x) | 40.93 -> 36.97 ns (1.11x) |

The gain is below the instruction-count ratio because the memory round trip and
the predicate-to-bitmask conversion are latency rather than throughput.

The in-order little cores gain least on both generations and by nearly the same
margin, 1.46x on Cortex-A510 and 1.53x on Cortex-A520, which suggests the limit
is in-order execution itself rather than any particular vector-unit
arrangement. The best ratio comes from the mid cores rather than the largest
one, presumably because the NEON path's 150 instructions cost relatively more
where execution resources are narrower.

## Why not movemask

movemask is the more obvious SVE target and was evaluated first. Base SVE and
SVE2 provide no predicate-to-general-register bitmask instruction; `PMOV` is
FEAT_SVE2p1 (Armv9.4-A). The horizontal reduction and the vector-to-general-
register transfer therefore survive translation, and the result is slower than
the existing NEON code.

Steady-state loop body, work instructions, loop-invariant setup hoisted:

| | `_mm_movemask_epi8` | `_mm_movemask_ps` | `_mm_movemask_pd` |
|---|---|---|---|
| NEON | 8 | 4 | 4 |
| SVE2 | 9 | 5 | 5 |

Measured on the same devices, per call, NEON -> SVE2. SVE2 is slower on every
core tested:

| | Cortex-X3 | Cortex-A715 | Cortex-A510 |
|---|---|---|---|
| `_mm_movemask_epi8` | 0.93 -> 1.80 ns | 1.97 -> 2.68 ns | 17.19 -> 19.00 ns |

| | Cortex-X4 | Cortex-A725 | Cortex-A520 |
|---|---|---|---|
| `_mm_movemask_epi8` | 0.84 -> 1.49 ns | 1.53 -> 1.97 ns | 12.47 -> 16.47 ns |

## Testing

No new test framework. `tests/impl.h` already lists all 14
`cmpistr*`/`cmpestr*` entry points and `tests/impl.cpp` references
`_SIDD_CMP_EQUAL_ANY` 30 times; `check-sve` reuses that harness.

```
make CROSS_COMPILE=aarch64-linux-gnu- check
    525 / 49 / 131 / 20 passed, 0 failed

make CROSS_COMPILE=aarch64-linux-gnu- check-sve
    vector length 16, 32 and 64 bytes: 525 / 49 / 131 / 20 passed, 0 failed each
```

On both devices, the same suites built with `SVE=1 FEATURE=sve2`: 725 tests,
0 failures on the Tensor G3 under Android 15 and again on the Tensor G5 under
Android 16. `objdump` confirms 6 `MATCH` instructions in the executed
`tests/main`.

Further checks:

- Preprocessor output with `SSE2NEON_ENABLE_SVE` unset is identical to current
  `master`; the `sse2neon.h` diff is 122 insertions and no deletions.
- GCC 13 and Clang 19, C and C++, project warning flags: no warnings from the
  new code. The Clang build also passes 525/525 on the device.
- `make check-macros`: 0 errors, the same 5 pre-existing warnings as `master`.
- `STRICT_ALIASING=1` with SVE2 enabled: passes, no new warnings from
  `sse2neon.h`.
- `make indent` (clang-format 22) touches only the new code and is idempotent.

## Not covered

- `SANITIZE=undefined` could not be run here: linking libubsan statically with
  the GNU cross toolchain fails on `__dynamic_cast`, identically on unmodified
  `master`. CI runs sanitizers on native Arm runners and is unaffected.
- `perf-tier.md` is not regenerated. The report generated from this branch is
  byte-identical to the one generated from `master`, so the change does not
  affect the tier analysis. The committed file is already out of sync on
  `master` in this environment by 289 lines, and regenerating it would add an
  unrelated diff produced by a possibly different libclang. It can be included
  if preferred.
- Neoverse is untested. The measurements cover six phone microarchitectures
  across two generations: Cortex-X3, A715, A510, X4, A725 and A520.
- MSVC defines no `__ARM_FEATURE_SVE2`, so it takes the NEON path by
  construction rather than by test.

## Question

Is a per-intrinsic, opt-in progression the direction you want for #537? The
alternative reading of that issue, porting genarchbench's `sse2sve.h` wholesale,
is a considerably larger change whose provenance and licensing would need
settling first. No code from it was used here.

If this direction is acceptable, the natural next step is a dedicated
`_mm_cmpistri` path: `MATCH` followed by `BRKB` and `CNTP` yields the index in
three instructions, since `CNTP` produces it directly and `BRKB` gives the
"no match returns 16" behaviour without forming a bitmask. That requires
modifying `SSE2NEON_COMP_AGG` and is deliberately excluded here.
