### PR TITLE
Drop the <fenv.h> dependency to stop leaking FE_* into includers

### DIFF
--- a/sse2neon.h
+++ b/sse2neon.h
@@ -413,7 +413,6 @@
 #endif
 #endif /* SSE2NEON_ARM64EC */
 
-#include <fenv.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2708,20 +2707,33 @@ FORCE_INLINE unsigned int _sse2neon_mm_get_flush_zero_mode(void)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_GET_ROUNDING_MODE
 FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE(void)
 {
-    const int mask = FE_TONEAREST | FE_DOWNWARD | FE_UPWARD | FE_TOWARDZERO;
-    switch (fegetround() & mask) {
-    case FE_TONEAREST:
+    // Read FPCR/FPSCR directly rather than going through <fenv.h>, so that the
+    // header does not leak the FE_* macros into everything that includes it.
+    union {
+        fpcr_bitfield field;
+#if SSE2NEON_ARCH_AARCH64
+        uint64_t value;
+#else
+        uint32_t value;
+#endif
+    } r;
+
+#if SSE2NEON_ARCH_AARCH64
+    r.value = _sse2neon_get_fpcr();
+#else
+    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+#endif
+
+    // FPCR.RMode occupies bits [23:22]: 0b00 nearest, 0b01 toward +infinity,
+    // 0b10 toward -infinity, 0b11 toward zero.
+    switch ((r.field.bit23 << 1) | r.field.bit22) {
+    case 0:
         return _MM_ROUND_NEAREST;
-    case FE_DOWNWARD:
-        return _MM_ROUND_DOWN;
-    case FE_UPWARD:
+    case 1:
         return _MM_ROUND_UP;
-    case FE_TOWARDZERO:
-        return _MM_ROUND_TOWARD_ZERO;
+    case 2:
+        return _MM_ROUND_DOWN;
     default:
-        // fegetround() must return _MM_ROUND_NEAREST, _MM_ROUND_DOWN,
-        // _MM_ROUND_UP, _MM_ROUND_TOWARD_ZERO on success. all the other error
-        // cases we treat them as FE_TOWARDZERO (truncate).
         return _MM_ROUND_TOWARD_ZERO;
     }
 }
@@ -3342,26 +3354,51 @@ FORCE_INLINE __m128 _mm_set_ps1(float _w)
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_MM_SET_ROUNDING_MODE
 FORCE_INLINE void _MM_SET_ROUNDING_MODE(int rounding)
 {
+    // Write FPCR/FPSCR directly rather than going through <fenv.h>, so that the
+    // header does not leak the FE_* macros into everything that includes it.
+    union {
+        fpcr_bitfield field;
+#if SSE2NEON_ARCH_AARCH64
+        uint64_t value;
+#else
+        uint32_t value;
+#endif
+    } r;
+
+#if SSE2NEON_ARCH_AARCH64
+    r.value = _sse2neon_get_fpcr();
+#else
+    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
+#endif
+
+    // FPCR.RMode occupies bits [23:22]. Anything that is not one of the four
+    // documented modes is treated as truncation, matching the previous
+    // behaviour of this function.
     switch (rounding) {
-    case _MM_ROUND_NEAREST:
-        rounding = FE_TONEAREST;
+    case _MM_ROUND_NEAREST: /* 0b00 */
+        r.field.bit22 = 0;
+        r.field.bit23 = 0;
         break;
-    case _MM_ROUND_DOWN:
-        rounding = FE_DOWNWARD;
+    case _MM_ROUND_UP: /* 0b01, toward +infinity */
+        r.field.bit22 = 1;
+        r.field.bit23 = 0;
         break;
-    case _MM_ROUND_UP:
-        rounding = FE_UPWARD;
+    case _MM_ROUND_DOWN: /* 0b10, toward -infinity */
+        r.field.bit22 = 0;
+        r.field.bit23 = 1;
         break;
-    case _MM_ROUND_TOWARD_ZERO:
-        rounding = FE_TOWARDZERO;
-        break;
+    case _MM_ROUND_TOWARD_ZERO: /* 0b11 */
     default:
-        // rounding must be _MM_ROUND_NEAREST, _MM_ROUND_DOWN, _MM_ROUND_UP,
-        // _MM_ROUND_TOWARD_ZERO. all the other invalid values we treat them as
-        // FE_TOWARDZERO (truncate).
-        rounding = FE_TOWARDZERO;
+        r.field.bit22 = 1;
+        r.field.bit23 = 1;
+        break;
     }
-    fesetround(rounding);
+
+#if SSE2NEON_ARCH_AARCH64
+    _sse2neon_set_fpcr(r.value);
+#else
+    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
+#endif
 }
 
 // Copy single-precision (32-bit) floating-point element a to the lower element

--- a/sse2neon.h
+++ b/sse2neon.h
@@ -2657,23 +2657,42 @@ FORCE_INLINE void _mm_free(void *addr)
 }
 #endif
 
-FORCE_INLINE uint64_t _sse2neon_get_fpcr(void)
+/* The AArch64 FPCR and the AArch32 FPSCR agree on the layout of every field
+ * sse2neon touches, but differ in width and in how they are accessed. The
+ * accessors below hide that difference so callers never need to branch on the
+ * architecture.
+ */
+#if SSE2NEON_ARCH_AARCH64
+typedef uint64_t _sse2neon_fpcr_t;
+#else
+typedef uint32_t _sse2neon_fpcr_t;
+#endif
+
+FORCE_INLINE _sse2neon_fpcr_t _sse2neon_get_fpcr(void)
 {
-    uint64_t value;
+    _sse2neon_fpcr_t value;
+#if SSE2NEON_ARCH_AARCH64
 #if SSE2NEON_COMPILER_MSVC && !SSE2NEON_COMPILER_CLANG
     value = _ReadStatusReg(ARM64_FPCR);
 #else
     __asm__ __volatile__("mrs %0, FPCR" : "=r"(value)); /* read */
 #endif
+#else
+    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(value)); /* read */
+#endif
     return value;
 }
 
-FORCE_INLINE void _sse2neon_set_fpcr(uint64_t value)
+FORCE_INLINE void _sse2neon_set_fpcr(_sse2neon_fpcr_t value)
 {
+#if SSE2NEON_ARCH_AARCH64
 #if SSE2NEON_COMPILER_MSVC && !SSE2NEON_COMPILER_CLANG
     _WriteStatusReg(ARM64_FPCR, value);
 #else
     __asm__ __volatile__("msr FPCR, %0" ::"r"(value)); /* write */
+#endif
+#else
+    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(value)); /* write */
 #endif
 }
 
@@ -2685,18 +2704,10 @@ FORCE_INLINE unsigned int _sse2neon_mm_get_flush_zero_mode(void)
 {
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     return r.field.bit24 ? _MM_FLUSH_ZERO_ON : _MM_FLUSH_ZERO_OFF;
 }
@@ -2711,18 +2722,10 @@ FORCE_INLINE unsigned int _MM_GET_ROUNDING_MODE(void)
     // header does not leak the FE_* macros into everything that includes it.
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     // FPCR.RMode occupies bits [23:22]: 0b00 nearest, 0b01 toward +infinity,
     // 0b10 toward -infinity, 0b11 toward zero.
@@ -3308,26 +3311,14 @@ FORCE_INLINE void _sse2neon_mm_set_flush_zero_mode(unsigned int flag)
     // regardless of the value of the FZ bit.
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     r.field.bit24 = (flag & _MM_FLUSH_ZERO_MASK) == _MM_FLUSH_ZERO_ON;
 
-#if SSE2NEON_ARCH_AARCH64
     _sse2neon_set_fpcr(r.value);
-#else
-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
-#endif
 }
 
 // Set packed single-precision (32-bit) floating-point elements in dst with the
@@ -3358,18 +3349,10 @@ FORCE_INLINE void _MM_SET_ROUNDING_MODE(int rounding)
     // header does not leak the FE_* macros into everything that includes it.
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     // FPCR.RMode occupies bits [23:22]. Anything that is not one of the four
     // documented modes is treated as truncation, matching the previous
@@ -3394,11 +3377,7 @@ FORCE_INLINE void _MM_SET_ROUNDING_MODE(int rounding)
         break;
     }
 
-#if SSE2NEON_ARCH_AARCH64
     _sse2neon_set_fpcr(r.value);
-#else
-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
-#endif
 }
 
 // Copy single-precision (32-bit) floating-point element a to the lower element
@@ -11613,18 +11592,10 @@ FORCE_INLINE unsigned int _sse2neon_mm_get_denormals_zero_mode(void)
 {
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     return r.field.bit24 ? _MM_DENORMALS_ZERO_ON : _MM_DENORMALS_ZERO_OFF;
 }
@@ -11694,26 +11665,14 @@ FORCE_INLINE void _sse2neon_mm_set_denormals_zero_mode(unsigned int flag)
     // regardless of the value of the FZ bit.
     union {
         fpcr_bitfield field;
-#if SSE2NEON_ARCH_AARCH64
-        uint64_t value;
-#else
-        uint32_t value;
-#endif
+        _sse2neon_fpcr_t value;
     } r;
 
-#if SSE2NEON_ARCH_AARCH64
     r.value = _sse2neon_get_fpcr();
-#else
-    __asm__ __volatile__("vmrs %0, FPSCR" : "=r"(r.value)); /* read */
-#endif
 
     r.field.bit24 = (flag & _MM_DENORMALS_ZERO_MASK) == _MM_DENORMALS_ZERO_ON;
 
-#if SSE2NEON_ARCH_AARCH64
     _sse2neon_set_fpcr(r.value);
-#else
-    __asm__ __volatile__("vmsr FPSCR, %0" ::"r"(r)); /* write */
-#endif
 }
 
 // Return the current 64-bit value of the processor's time-stamp counter.


### PR DESCRIPTION
Fixes #767.

sse2neon.h includes <fenv.h>, so every translation unit that includes sse2neon.h also gets FE_INVALID, FE_TONEAREST and the rest. That breaks projects which deliberately define their own: RecoilEngine reports streflop emitting "FE_XXX flags were already defined and will be redefined" for every file, because streflop replaces the system FE_* macros on purpose.

The include exists only for _MM_GET_ROUNDING_MODE and _MM_SET_ROUNDING_MODE, which is more indirection than the job needs. The rounding mode lives in FPCR.RMode, bits [23:22], and this header already has everything required to reach it: _sse2neon_get_fpcr()/_sse2neon_set_fpcr() and the fpcr_bitfield struct, whose bit22 and bit23 members are exactly that field. The sibling _MM_GET_FLUSH_ZERO_MODE and _MM_SET_FLUSH_ZERO_MODE already manipulate FPCR this way, so the two functions now follow the same shape. On AArch32 they use the same vmrs/vmsr FPSCR access as those siblings.

Mapping, per the Arm ARM: 0b00 nearest, 0b01 toward +infinity, 0b10 toward -infinity, 0b11 toward zero. Invalid input to _MM_SET_ROUNDING_MODE still falls back to truncation, matching the previous behaviour.

Besides fixing the reported problem this removes a libm dependency and replaces a libc call with a single MRS.

Verified equivalent rather than assumed: a test that sets each mode through _MM_SET_ROUNDING_MODE and then reads fegetround() finds them in agreement for all four modes, on QEMU and on a Tensor G5 device, and 1.0f/3.0f differs between the round-down and round-up settings, so the FPCR write demonstrably takes effect.

No new tests. The existing harness already covers this well: test_mm_set_rounding_mode checks that _mm_round_ps(_MM_FROUND_CUR_DIRECTION) agrees with the explicit-mode form in each of the four modes, and nine _mm_cvt* tests set rounding modes and validate their results. make CROSS_COMPILE=aarch64-linux-gnu- check passes 525/49/131/20 with zero failures, and again with STRICT_ALIASING=1. The AArch32 path was compile-checked and confirmed to emit vmrs/vmsr.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `<fenv.h>` dependency from `sse2neon.h` by reading/writing FPCR/FPSCR directly for rounding mode. This stops leaking `FE_*` into includers and fixes redefinition conflicts (Fixes #767) without changing observable behavior.

- `_MM_GET_ROUNDING_MODE`/`_MM_SET_ROUNDING_MODE` now map FPCR.RMode bits [23:22] (00 nearest, 01 up, 10 down, 11 toward zero); invalid input still truncates.
- Unifies `_sse2neon_get_fpcr`/`_sse2neon_set_fpcr` across AArch64/AArch32 via a new `_sse2neon_fpcr_t`, removing per-callsite `#if` and using `mrs/msr` or `vmrs/vmsr` as appropriate.
- Updates flush-zero and denormals-zero helpers to use the unified accessors; fixes an AArch32 write that previously passed a union instead of its value.
- Drops `fegetround`/`fesetround` and any `libm`/`libc` calls; projects redefining `FE_*` (e.g., streflop) no longer see warnings.
- No migration required; existing tests already cover rounding-mode behavior.

<sup>Written for commit 9197ec24f051736d740c3579746be65695b18260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DLTcollab/sse2neon/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

